### PR TITLE
Resource name

### DIFF
--- a/graph/decoder/decode.go
+++ b/graph/decoder/decode.go
@@ -144,7 +144,10 @@ func (d *decode) addResource(block *hcl.Block, ctx *DecodeContext) hcl.Diagnosti
 	diags = append(diags, morediags...)
 
 	// create resource node
-	res := d.graph.AddResource(def)
+	res := d.graph.AddResource(resource.Resource{
+		Name: resname,
+		Def:  def,
+	})
 
 	// collect refs, we'll need to connect them later
 	for _, ref := range refs {

--- a/graph/decoder/decode_test.go
+++ b/graph/decoder/decode_test.go
@@ -41,8 +41,8 @@ func TestDecodeBody(t *testing.T) {
 			`),
 			ctx: &decoder.DecodeContext{Resources: resource.RegistryFromResources(&fooRes{})},
 			wantSnap: graph.Snapshot{
-				Resources: []resource.Definition{
-					&fooRes{Input: strptr("hello")},
+				Resources: []resource.Resource{
+					{Name: "bar", Def: &fooRes{Input: strptr("hello")}},
 				},
 			},
 			wantProj: config.Project{Name: "test"},
@@ -61,8 +61,8 @@ func TestDecodeBody(t *testing.T) {
 			`),
 			ctx: &decoder.DecodeContext{Resources: resource.RegistryFromResources(&fooRes{})},
 			wantSnap: graph.Snapshot{
-				Resources: []resource.Definition{
-					&fooRes{},
+				Resources: []resource.Resource{
+					{Name: "bar", Def: &fooRes{}},
 				},
 				Sources: []config.SourceInfo{
 					{SHA: "abc", MD5: "def", Len: 123, Ext: ".tar.gz"},
@@ -86,9 +86,9 @@ func TestDecodeBody(t *testing.T) {
 			`),
 			ctx: &decoder.DecodeContext{Resources: resource.RegistryFromResources(&fooRes{}, &barRes{})},
 			wantSnap: graph.Snapshot{
-				Resources: []resource.Definition{
-					&fooRes{Input: strptr("hello")},
-					&barRes{Input: strptr("hello")},
+				Resources: []resource.Resource{
+					{Name: "bar", Def: &fooRes{Input: strptr("hello")}},
+					{Name: "baz", Def: &barRes{Input: strptr("hello")}},
 				},
 			},
 			wantProj: config.Project{Name: "test"},
@@ -106,9 +106,9 @@ func TestDecodeBody(t *testing.T) {
 			`),
 			ctx: &decoder.DecodeContext{Resources: resource.RegistryFromResources(&fooRes{}, &barRes{})},
 			wantSnap: graph.Snapshot{
-				Resources: []resource.Definition{
-					&fooRes{Input: strptr("hello")},
-					&barRes{},
+				Resources: []resource.Resource{
+					{Name: "bar", Def: &fooRes{Input: strptr("hello")}},
+					{Name: "foo", Def: &barRes{}},
 				},
 				References: []graph.SnapshotRef{
 					{Source: 0, Target: 1, SourceIndex: []int{1}, TargetIndex: []int{0}},
@@ -126,8 +126,8 @@ func TestDecodeBody(t *testing.T) {
 			`),
 			ctx: &decoder.DecodeContext{Resources: resource.RegistryFromResources(&fooRes{})},
 			wantSnap: graph.Snapshot{
-				Resources: []resource.Definition{
-					&fooRes{Input: strptr("3.14159")},
+				Resources: []resource.Resource{
+					{Name: "bar", Def: &fooRes{Input: strptr("3.14159")}},
 				},
 			},
 			wantProj: config.Project{Name: "test"},

--- a/graph/edges.go
+++ b/graph/edges.go
@@ -27,6 +27,6 @@ type Field struct {
 // Value returns the underlying value from the resource definition the Field
 // points to.
 func (f Field) Value() reflect.Value {
-	val := reflect.Indirect(reflect.ValueOf(f.Resource.Definition))
+	val := reflect.Indirect(reflect.ValueOf(f.Resource.Config.Def))
 	return val.FieldByIndex(f.Index)
 }

--- a/graph/edges_test.go
+++ b/graph/edges_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/func/func/graph"
+	"github.com/func/func/resource"
 )
 
 func TestNoop(t *testing.T) {
@@ -12,13 +13,18 @@ func TestNoop(t *testing.T) {
 }
 
 func ExampleField_Value() {
-	res := &graph.Resource{Definition: SomeDefinition{
-		Str: "hello",
-		Int: 123,
-		Nested: Nested{
-			Str: "world",
+	res := &graph.Resource{
+		Config: resource.Resource{
+			Name: "foo",
+			Def: SomeDefinition{
+				Str: "hello",
+				Int: 123,
+				Nested: Nested{
+					Str: "world",
+				},
+			},
 		},
-	}}
+	}
 
 	f1 := graph.Field{Resource: res, Index: []int{0}}
 	f2 := graph.Field{Resource: res, Index: []int{1}}

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -22,27 +22,27 @@ func New() *Graph {
 }
 
 // AddResource adds a new resource definition to the graph.
-func (g *Graph) AddResource(def resource.Definition) *Resource {
-	res := &Resource{
-		g:          g,
-		Node:       g.NewNode(),
-		Definition: def,
+func (g *Graph) AddResource(res resource.Resource) *Resource {
+	node := &Resource{
+		g:      g,
+		Node:   g.NewNode(),
+		Config: res,
 	}
-	g.AddNode(res)
-	return res
+	g.AddNode(node)
+	return node
 }
 
 // AddSource adds a source input to a given resource. The resource must be
 // added to the graph before adding source.
 func (g *Graph) AddSource(res *Resource, info config.SourceInfo) *Source {
-	n := &Source{
+	node := &Source{
 		g:          g,
 		Node:       g.NewNode(),
 		SourceInfo: info,
 	}
-	g.AddNode(n)
-	g.SetLine(g.NewLine(n, res))
-	return n
+	g.AddNode(node)
+	g.SetLine(g.NewLine(node, res))
+	return node
 }
 
 // AddDependency adds a dependency between two resources. Both resources in the

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -36,9 +36,9 @@ func (g *Graph) AddResource(res resource.Resource) *Resource {
 // added to the graph before adding source.
 func (g *Graph) AddSource(res *Resource, info config.SourceInfo) *Source {
 	node := &Source{
-		g:          g,
-		Node:       g.NewNode(),
-		SourceInfo: info,
+		g:      g,
+		Node:   g.NewNode(),
+		Config: info,
 	}
 	g.AddNode(node)
 	g.SetLine(g.NewLine(node, res))

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/func/func/config"
 	"github.com/func/func/graph"
+	"github.com/func/func/resource"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestGraph_AddResource(t *testing.T) {
 	g := graph.New()
-	res := g.AddResource(&mockRes{Value: "foo"})
+	res := g.AddResource(resource.Resource{Name: "foo", Def: &mockRes{Value: "foo"}})
 
 	got := g.Resources()
 	want := []*graph.Resource{res}
@@ -25,7 +26,7 @@ func TestGraph_AddResource(t *testing.T) {
 
 func TestGraph_AddSource(t *testing.T) {
 	g := graph.New()
-	res := g.AddResource(&mockRes{Value: "foo"})
+	res := g.AddResource(resource.Resource{Name: "foo", Def: &mockRes{Value: "foo"}})
 	src := g.AddSource(res, config.SourceInfo{SHA: "123"})
 
 	got := g.Sources()
@@ -40,8 +41,8 @@ func TestGraph_AddSource(t *testing.T) {
 
 func TestGraph_AddDependency(t *testing.T) {
 	g := graph.New()
-	res1 := g.AddResource(&mockRes{Value: "foo"})
-	res2 := g.AddResource(&mockRes{Value: "bar"})
+	res1 := g.AddResource(resource.Resource{Name: "foo", Def: &mockRes{Value: "foo"}})
+	res2 := g.AddResource(resource.Resource{Name: "bar", Def: &mockRes{Value: "bar"}})
 	ref := graph.Reference{
 		Source: graph.Field{Resource: res1, Index: []int{0}},
 		Target: graph.Field{Resource: res2, Index: []int{0}},
@@ -80,7 +81,7 @@ func TestGraph_AddDependency(t *testing.T) {
 
 func TestGraph_reverse(t *testing.T) {
 	g := graph.New()
-	res := g.AddResource(&mockRes{Value: "foo"})
+	res := g.AddResource(resource.Resource{Name: "foo", Def: &mockRes{Value: "foo"}})
 	g.AddSource(res, config.SourceInfo{SHA: "abc"})
 
 	// Traverse to source, then back to resource

--- a/graph/nodes.go
+++ b/graph/nodes.go
@@ -58,8 +58,8 @@ func (n *Resource) Dependents() []Reference {
 // A Source node contains the source code for a resource.
 type Source struct {
 	graph.Node
-	g *Graph
-	config.SourceInfo
+	g      *Graph
+	Config config.SourceInfo
 }
 
 // Resource returns the resource the source belongs to.

--- a/graph/nodes.go
+++ b/graph/nodes.go
@@ -9,8 +9,8 @@ import (
 // A Resource is an instance of a resource definition added to the graph.
 type Resource struct {
 	graph.Node
-	g *Graph
-	resource.Definition
+	g      *Graph
+	Config resource.Resource
 }
 
 // Sources return all sources belonging to a resource.

--- a/graph/snapshot.go
+++ b/graph/snapshot.go
@@ -16,7 +16,7 @@ import (
 // of them in tests.
 type Snapshot struct {
 	// Nodes
-	Resources []resource.Definition
+	Resources []resource.Resource
 	Sources   []config.SourceInfo
 
 	// Edges
@@ -97,7 +97,7 @@ func (g *Graph) Snapshot() Snapshot {
 	resIndex := make(map[*Resource]int)
 	for _, n := range rr {
 		resIndex[n] = len(s.Resources)
-		s.Resources = append(s.Resources, n.Definition)
+		s.Resources = append(s.Resources, n.Config)
 	}
 
 	ss := g.Sources()

--- a/graph/snapshot.go
+++ b/graph/snapshot.go
@@ -105,7 +105,7 @@ func (g *Graph) Snapshot() Snapshot {
 	srcIndex := make(map[*Source]int)
 	for _, n := range ss {
 		srcIndex[n] = len(s.Sources)
-		s.Sources = append(s.Sources, n.SourceInfo)
+		s.Sources = append(s.Sources, n.Config)
 	}
 
 	// Edges

--- a/graph/snapshot_test.go
+++ b/graph/snapshot_test.go
@@ -15,10 +15,10 @@ import (
 func TestSnapshot_roundtrip(t *testing.T) {
 	start := graph.Snapshot{
 		// Nodes
-		Resources: []resource.Definition{
-			&mockResource{Value: "foo"},
-			&mockResource{Value: "bar"},
-			&mockResource{Value: "baz"},
+		Resources: []resource.Resource{
+			{Name: "foo", Def: &mockResource{Value: "foo"}},
+			{Name: "bar", Def: &mockResource{Value: "bar"}},
+			{Name: "baz", Def: &mockResource{Value: "baz"}},
 		},
 		Sources: []config.SourceInfo{
 			{SHA: "123"},
@@ -69,7 +69,7 @@ func TestFromSnapshot_errors(t *testing.T) {
 		{
 			"NoSourceOwner",
 			graph.Snapshot{
-				Resources:       []resource.Definition{&mockResource{Value: "foo"}},
+				Resources:       []resource.Resource{{Name: "foo", Def: &mockResource{Value: "foo"}}},
 				Sources:         []config.SourceInfo{{SHA: "123"}},
 				ResourceSources: map[int][]int{}, // empty
 			},
@@ -77,8 +77,8 @@ func TestFromSnapshot_errors(t *testing.T) {
 		{
 			"NoResourceSource",
 			graph.Snapshot{
-				Resources: []resource.Definition{
-					&mockResource{Value: "foo"},
+				Resources: []resource.Resource{
+					{Name: "foo", Def: &mockResource{Value: "foo"}},
 				},
 				References: []graph.SnapshotRef{
 					{Source: 1, Target: 0, SourceIndex: []int{0}, TargetIndex: []int{0}}, // Invalid Source
@@ -88,8 +88,8 @@ func TestFromSnapshot_errors(t *testing.T) {
 		{
 			"NoResourceTarget",
 			graph.Snapshot{
-				Resources: []resource.Definition{
-					&mockResource{Value: "foo"},
+				Resources: []resource.Resource{
+					{Name: "foo", Def: &mockResource{Value: "foo"}},
 				},
 				References: []graph.SnapshotRef{
 					{Source: 0, Target: 1, SourceIndex: []int{0}, TargetIndex: []int{0}}, // Invalid Target
@@ -120,9 +120,9 @@ func ExampleFromSnapshot() {
 
 	snap := graph.Snapshot{
 		// Nodes
-		Resources: []resource.Definition{
-			&mockResource{Value: "foo"},
-			&mockResource{Value: "bar"},
+		Resources: []resource.Resource{
+			{Name: "foo", Def: &mockResource{Value: "foo"}},
+			{Name: "bar", Def: &mockResource{Value: "bar"}},
 		},
 		Sources: []config.SourceInfo{
 			{SHA: "123"},
@@ -152,9 +152,9 @@ func ExampleFromSnapshot() {
 
 func ExampleSnapshot_Diff() {
 	snap1 := graph.Snapshot{
-		Resources: []resource.Definition{
-			&mockResource{Value: "foo"},
-			&mockResource{Value: "bar"},
+		Resources: []resource.Resource{
+			{Name: "foo", Def: &mockResource{Value: "foo"}},
+			{Name: "bar", Def: &mockResource{Value: "bar"}},
 		},
 		Sources: []config.SourceInfo{
 			{SHA: "123"},
@@ -162,8 +162,8 @@ func ExampleSnapshot_Diff() {
 	}
 
 	snap2 := graph.Snapshot{
-		Resources: []resource.Definition{
-			&mockResource{Value: "foo"},
+		Resources: []resource.Resource{
+			{Name: "foo", Def: &mockResource{Value: "foo"}},
 		},
 		Sources: []config.SourceInfo{
 			{SHA: "abc"},
@@ -173,7 +173,7 @@ func ExampleSnapshot_Diff() {
 	fmt.Println(snap1.Diff(snap2))
 	// Output:
 	// {graph.Snapshot}.Resources[1->?]:
-	// 	-: &graph_test.mockResource{Value: "bar"}
+	// 	-: resource.Resource{Name: "bar", Def: &graph_test.mockResource{Value: "bar"}}
 	// 	+: <non-existent>
 	// {graph.Snapshot}.Sources[0].SHA:
 	// 	-: "123"

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -10,3 +10,9 @@ type Definition interface {
 	// configuration provided by the user.
 	Type() string
 }
+
+// A Resource is an instance of a resource supplied by the user.
+type Resource struct {
+	Name string     // Name used in resource config.
+	Def  Definition // Def is the resolved definition for resource, including user data.
+}

--- a/server/server.go
+++ b/server/server.go
@@ -78,15 +78,15 @@ func (s *Server) Apply(ctx context.Context, req *api.ApplyRequest) (*api.ApplyRe
 		sr := &api.SourceRequired{}
 		for _, src := range missing {
 			u, err := s.Source.NewUpload(source.UploadConfig{
-				Filename:      src.SHA + src.Ext,
-				ContentMD5:    src.MD5,
-				ContentLength: src.Len,
+				Filename:      src.Config.SHA + src.Config.Ext,
+				ContentMD5:    src.Config.MD5,
+				ContentLength: src.Config.Len,
 			})
 			if err != nil {
 				logger.Error("Could not create upload url", zap.Error(err))
 				return nil, twirp.NewError(twirp.Unavailable, "request upload")
 			}
-			sr.Uploads = append(sr.Uploads, &api.UploadRequest{Digest: src.SHA, Url: u.URL, Headers: u.Headers})
+			sr.Uploads = append(sr.Uploads, &api.UploadRequest{Digest: src.Config.SHA, Url: u.URL, Headers: u.Headers})
 		}
 		return &api.ApplyResponse{Response: &api.ApplyResponse_SourceRequest{SourceRequest: sr}}, nil
 	}
@@ -107,7 +107,7 @@ func (s *Server) missingSource(ctx context.Context, sources []*graph.Source) ([]
 	for _, src := range sources {
 		src := src
 		g.Go(func() error {
-			key := src.SHA + src.Ext
+			key := src.Config.SHA + src.Config.Ext
 			ok, err := s.Source.Has(ctx, key)
 			if err != nil {
 				return errors.Wrapf(err, "check %s", key)
@@ -131,7 +131,7 @@ type sources []*graph.Source
 func (ss sources) Hashes() []string {
 	list := make([]string, len(ss))
 	for i, s := range ss {
-		list[i] = s.SHA
+		list[i] = s.Config.SHA
 	}
 	return list
 }


### PR DESCRIPTION
A common `resource.Resource` is used to capture the resource name and definition. The node in the graph wraps this resource, allowing the name to be preserved.

Also update `Source` node to match.

Resource and Source nodes no longer embed the underlying config in their type. This keeps it a bit easier to keep track of which resource is in question.