### PR TITLE
Decode nested config block

### DIFF
--- a/graph/decoder/decode_test.go
+++ b/graph/decoder/decode_test.go
@@ -172,6 +172,98 @@ func TestDecodeBody(t *testing.T) {
 			wantProj: config.Project{Name: "test"},
 		},
 		{
+			name: "StructBlock",
+			body: parseBody(t, `
+				project "test" {}
+				resource "complex" "foo" {
+					nested {
+						sub {
+							value = "hello"
+						}
+					}
+				}
+			`),
+			ctx: &decoder.DecodeContext{Resources: resource.RegistryFromResources(&complexDef{})},
+			wantSnap: graph.Snapshot{
+				Resources: []resource.Resource{
+					{Name: "foo", Def: &complexDef{
+						Child: &Child{
+							Sub: sub{
+								Val: "hello",
+							},
+						},
+					}},
+				},
+			},
+			wantProj: config.Project{Name: "test"},
+		},
+		{
+			name: "MultipleBlocks",
+			body: parseBody(t, `
+				project "test" {}
+				resource "complex" "foo" {
+					nested {
+						value = "hello"
+					}
+					nested {
+						value = "hello"
+					}
+				}
+			`),
+			ctx: &decoder.DecodeContext{Resources: resource.RegistryFromResources(&complexDef{})},
+			diags: hcl.Diagnostics{{
+				Severity: hcl.DiagError,
+				Summary:  "Duplicate nested block",
+				Detail:   "Only one nested block is allowed. Another was defined on line 3",
+				Subject: &hcl.Range{
+					Start: hcl.Pos{Line: 6, Column: 6},
+					End:   hcl.Pos{Line: 6, Column: 12},
+				},
+			}},
+			wantProj: config.Project{Name: "test"},
+		},
+		{
+			name: "MissingBlock",
+			body: parseBody(t, `
+				project "test" {}
+				resource "qux" "foo" {
+					# required block not set
+				}
+			`),
+			ctx: &decoder.DecodeContext{Resources: resource.RegistryFromResources(&quxDef{})},
+			diags: hcl.Diagnostics{{
+				Severity: hcl.DiagError,
+				Summary:  "Missing required_field block",
+				Detail:   "A required_field block is required.",
+				Subject: &hcl.Range{
+					Start: hcl.Pos{Line: 4, Column: 6},
+					End:   hcl.Pos{Line: 4, Column: 6},
+				},
+			}},
+			wantProj: config.Project{Name: "test"},
+		},
+		{
+			name: "MissingNestedBlock",
+			body: parseBody(t, `
+				project "test" {}
+				resource "complex" "foo" {
+					nested {
+					}
+				}
+			`),
+			ctx: &decoder.DecodeContext{Resources: resource.RegistryFromResources(&complexDef{})},
+			diags: hcl.Diagnostics{{
+				Severity: hcl.DiagError,
+				Summary:  "Missing sub block",
+				Detail:   "A sub block is required.",
+				Subject: &hcl.Range{
+					Start: hcl.Pos{Line: 4, Column: 7},
+					End:   hcl.Pos{Line: 4, Column: 7},
+				},
+			}},
+			wantProj: config.Project{Name: "test"},
+		},
+		{
 			name: "NoProject",
 			body: parseBody(t, `
 				resource "foo" "bar" {
@@ -364,11 +456,27 @@ type bazDef struct {
 
 func (r *bazDef) Type() string { return "baz" }
 
+type quxDef struct {
+	resource.Definition
+	Required Child `input:"required_field"`
+}
+
+func (r *quxDef) Type() string { return "qux" }
+
 type complexDef struct {
 	resource.Definition
 
 	Map   *map[string]string `input:"map"`
 	Slice *[]string          `input:"slice"`
+	Child *Child             `input:"nested"`
+}
+
+type Child struct {
+	Sub sub `input:"sub"`
+}
+
+type sub struct {
+	Val string `input:"value"`
 }
 
 func (r *complexDef) Type() string { return "complex" }

--- a/graph/decoder/decode_test.go
+++ b/graph/decoder/decode_test.go
@@ -134,6 +134,44 @@ func TestDecodeBody(t *testing.T) {
 			wantProj: config.Project{Name: "test"},
 		},
 		{
+			name: "Map",
+			body: parseBody(t, `
+				project "test" {}
+				resource "complex" "foo" {
+					map = {
+						foo = "bar"
+					}
+				}
+			`),
+			ctx: &decoder.DecodeContext{Resources: resource.RegistryFromResources(&complexDef{})},
+			wantSnap: graph.Snapshot{
+				Resources: []resource.Resource{
+					{Name: "foo", Def: &complexDef{
+						Map: &map[string]string{"foo": "bar"},
+					}},
+				},
+			},
+			wantProj: config.Project{Name: "test"},
+		},
+		{
+			name: "Slice",
+			body: parseBody(t, `
+				project "test" {}
+				resource "complex" "foo" {
+					slice = ["hello", "world"]
+				}
+			`),
+			ctx: &decoder.DecodeContext{Resources: resource.RegistryFromResources(&complexDef{})},
+			wantSnap: graph.Snapshot{
+				Resources: []resource.Resource{
+					{Name: "foo", Def: &complexDef{
+						Slice: &[]string{"hello", "world"},
+					}},
+				},
+			},
+			wantProj: config.Project{Name: "test"},
+		},
+		{
 			name: "NoProject",
 			body: parseBody(t, `
 				resource "foo" "bar" {
@@ -325,5 +363,14 @@ type bazDef struct {
 }
 
 func (r *bazDef) Type() string { return "baz" }
+
+type complexDef struct {
+	resource.Definition
+
+	Map   *map[string]string `input:"map"`
+	Slice *[]string          `input:"slice"`
+}
+
+func (r *complexDef) Type() string { return "complex" }
 
 func strptr(str string) *string { return &str }

--- a/graph/decoder/doc.go
+++ b/graph/decoder/doc.go
@@ -16,6 +16,10 @@
 //
 //   resource "aws_lambda_function" "test" {
 //       name = "example"
+//
+//       sub {
+//           value = 123
+//       }
 //   }
 //
 // The second label ("test") is used when referring to resources from other
@@ -27,18 +31,26 @@
 //
 //   type MyResource struct {
 //       // Inputs
-//       Name string `input:"input"`
-//       Age  *int   `input:"age"`
+//       Name    string   `input:"input"`
+//       Age     *int     `input:"age"`
+//       Address *Address `input:"address"`
 //
 //       // Outputs
 //       Nickname string `output:"nick"`
+//   }
+//
+//   type Address struct {
+//       StreetName string  `input:"street"`
+//       Country    *string `input:"country"`
 //   }
 //
 // The value in the tag is matched to the attribute in hcl. This means `nick`
 // is the word to use in the example above. By convention, tag names should be
 // lower_snake_case.
 //
-// If an input is set on a pointer, the input is optional.
+// If an input is set on a pointer, the input is optional. In this example,
+// Address is a pointer and thus the entire block is optional. However, if the
+// block is provided, the address required a StreetName.
 //
 // References
 //

--- a/graph/decoder/io.go
+++ b/graph/decoder/io.go
@@ -1,6 +1,7 @@
 package decoder
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/func/func/resource"
@@ -25,7 +26,13 @@ func decodeInput(val reflect.Value, config hcl.Body) (vals map[string]cty.Value,
 	}
 
 	vals = make(map[string]cty.Value)
+
+	// Attributes
 	for _, input := range inputs {
+		if isBlock(input) {
+			continue
+		}
+
 		attr, ok := cont.Attributes[input.Name]
 		if !ok {
 			// Optional attribute was not set
@@ -55,6 +62,68 @@ func decodeInput(val reflect.Value, config hcl.Body) (vals map[string]cty.Value,
 		diags = append(diags, morediags...)
 	}
 
+	// Blocks
+	blocksByType := cont.Blocks.ByType()
+	for _, input := range inputs {
+		if !isBlock(input) {
+			continue
+		}
+		blocks := blocksByType[input.Name]
+
+		if len(blocks) == 0 {
+			if input.Type.Kind() == reflect.Ptr {
+				// Missing optional block
+				continue
+			}
+			// Missing required block
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Missing %s block", input.Name),
+				Detail:   fmt.Sprintf("A %s block is required.", input.Name),
+				Subject:  config.MissingItemRange().Ptr(),
+			})
+			continue
+		}
+		if len(blocks) > 1 {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Duplicate %s block", input.Name),
+				Detail: fmt.Sprintf(
+					"Only one %s block is allowed. Another was defined on line %d",
+					input.Name,
+					blocks[0].DefRange.Start.Line,
+				),
+				Subject: blocks[1].DefRange.Ptr(),
+			})
+			continue
+		}
+
+		if input.Type.Kind() == reflect.Ptr {
+			// Initialize struct
+			v := reflect.New(input.Type.Elem())
+			val.Field(input.Index).Set(v)
+		}
+
+		field := reflect.Indirect(val.Field(input.Index))
+
+		if !field.IsValid() {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("huh"),
+				Subject:  blocks[0].DefRange.Ptr(),
+			})
+			continue
+		}
+
+		block := blocks[0]
+		kv, r, d := decodeInput(field, block.Body)
+		for k, v := range kv {
+			vals[k] = v
+		}
+		refs = append(refs, r...)
+		diags = append(diags, d...)
+	}
+
 	return vals, refs, diags
 }
 
@@ -64,9 +133,27 @@ type ref struct {
 	field resource.Field
 }
 
+func isBlock(f resource.Field) bool {
+	if f.Type.Kind() == reflect.Struct {
+		// Required block
+		return true
+	}
+	if f.Type.Kind() == reflect.Ptr && f.Type.Elem().Kind() == reflect.Struct {
+		// Optional block
+		return true
+	}
+	return f.Type.Kind() == reflect.Struct
+}
+
 func inputSchema(ff []resource.Field) *hcl.BodySchema {
 	schema := &hcl.BodySchema{}
 	for _, f := range ff {
+		if isBlock(f) {
+			schema.Blocks = append(schema.Blocks, hcl.BlockHeaderSchema{
+				Type: f.Name,
+			})
+			continue
+		}
 		schema.Attributes = append(schema.Attributes, hcl.AttributeSchema{
 			Name:     f.Name,
 			Required: f.Type.Kind() != reflect.Ptr,


### PR DESCRIPTION
Add support for decoding a nested block, such as:

```hcl
resource "aws_apigateway_rest_api" "api" {
  endpoint_configuration {
    types = ["EDGE"]
  }
}
```

Unlike hcl2, only one block is supported.

Also added tests for slices and maps, even if no code changes were required.