### PR TITLE
Fix update

### DIFF
--- a/provider/aws/iam_role_policy.go
+++ b/provider/aws/iam_role_policy.go
@@ -80,12 +80,12 @@ func (p *IAMRolePolicy) Update(ctx context.Context, r *resource.UpdateRequest) e
 
 	// Delete previous
 	prev := r.Previous.(*IAMRolePolicy)
-	if err := prev.Delete(ctx, nil); err != nil {
+	if err := prev.Delete(ctx, r.DeleteRequest()); err != nil {
 		return errors.Wrap(err, "update-delete")
 	}
 
 	// Create next
-	if err := p.Create(ctx, nil); err != nil {
+	if err := p.Create(ctx, r.CreateRequest()); err != nil {
 		return errors.Wrap(err, "update-create")
 	}
 

--- a/provider/aws/iam_role_policy_attachment.go
+++ b/provider/aws/iam_role_policy_attachment.go
@@ -86,12 +86,12 @@ func (p *IAMRolePolicyAttachment) Update(ctx context.Context, r *resource.Update
 
 	// Delete previous
 	prev := r.Previous.(*IAMRolePolicyAttachment)
-	if err := prev.Delete(ctx, nil); err != nil {
+	if err := prev.Delete(ctx, r.DeleteRequest()); err != nil {
 		return errors.Wrap(err, "update-delete")
 	}
 
 	// Create next
-	if err := p.Create(ctx, nil); err != nil {
+	if err := p.Create(ctx, r.CreateRequest()); err != nil {
 		return errors.Wrap(err, "update-create")
 	}
 

--- a/resource/request.go
+++ b/resource/request.go
@@ -47,6 +47,21 @@ type UpdateRequest struct {
 	ConfigChanged bool
 }
 
+// CreateRequest converts the update to a Create Request.
+func (r *UpdateRequest) CreateRequest() *CreateRequest {
+	return &CreateRequest{
+		Auth:   r.Auth,
+		Source: r.Source,
+	}
+}
+
+// DeleteRequest converts the update to a Delete Request.
+func (r *UpdateRequest) DeleteRequest() *DeleteRequest {
+	return &DeleteRequest{
+		Auth: r.Auth,
+	}
+}
+
 // A DeleteRequest is passed to a resource when it is being deleted.
 type DeleteRequest struct {
 	Auth AuthProvider


### PR DESCRIPTION
When a resource is being updated through delete-create, we still need access to the request in order to get `Auth` from it.