### PR TITLE
Clean up AWS provider service creation

### DIFF
--- a/docs/resources/aws/apigateway_deployment.md
+++ b/docs/resources/aws/apigateway_deployment.md
@@ -13,12 +13,12 @@ APIGatewayDeployment provides a Serverless REST API.
 | input | [`cache_cluster_size`](#cache_cluster_size) | `string` |  |
 | input | [`canary_settings`](#canary_settings) | `APIGatewayDeploymentCanarySettings` |  |
 | input | [`description`](#description) | `string` |  |
+| input | [`region`](#region) | `string` | required |
 | input | [`rest_api_id`](#rest_api_id) | `string` | required |
 | input | [`state_description`](#state_description) | `string` |  |
 | input | [`stage_name`](#stage_name) | `string` |  |
 | input | [`tracing_enabled`](#tracing_enabled) | `bool` |  |
 | input | [`variables`](#variables) | `map` |  |
-| input | [`region`](#region) | `string` | required |
 | input | [`change_trigger`](#change_trigger) | `string` | required |
 | output | [`api_summary`](#api_summary) | `map` ||
 | output | [`created_date`](#created_date) | `time` ||
@@ -63,6 +63,12 @@ a canary release deployment.
 
 The description for the Deployment resource to create.
 
+### region
+
+`string`
+
+The region the API Gateway is deployed to.
+
 ### rest_api_id
 
 `string`
@@ -96,12 +102,6 @@ A map that defines the stage variables for the Stage resource that is
 associated with the new deployment. Variable names can have alphanumeric
 and underscore characters, and the values must match
 `[A-Za-z0-9-._~:/?#&=,]+`.
-
-### region
-
-`string`
-
-
 
 ### change_trigger
 

--- a/docs/resources/aws/apigateway_integration.md
+++ b/docs/resources/aws/apigateway_integration.md
@@ -19,6 +19,7 @@ API.
 | input | [`http_method`](#http_method) | `string` | required |
 | input | [`integration_http_method`](#integration_http_method) | `string` | required |
 | input | [`passthrough_behavior`](#passthrough_behavior) | `string` |  |
+| input | [`region`](#region) | `string` | required |
 | input | [`request_parameters`](#request_parameters) | `map` |  |
 | input | [`request_templates`](#request_templates) | `map` |  |
 | input | [`resource_id`](#resource_id) | `string` | required |
@@ -26,7 +27,6 @@ API.
 | input | [`timeout`](#timeout) | `time` |  |
 | input | [`type`](#type) | `string` | required |
 | input | [`uri`](#uri) | `string` |  |
-| input | [`region`](#region) | `string` | required |
 | output | [`integration_responses`](#integration_responses) | `map` ||
 
 
@@ -122,6 +122,12 @@ There are three valid values:
 - `WHEN_NO_TEMPLATES` allows pass-through when the integration has NO content
   types mapped to templates. However if there is at least one content type
   defined, unmapped content types will be rejected with the same 415 response.
+
+### region
+
+`string`
+
+The region the API Gateway is deployed to.
 
 ### request_parameters
 
@@ -225,12 +231,6 @@ Specifies Uniform Resource Identifier (URI) of the integration endpoint.
   the uri can be either
   `arn:aws:apigateway:us-west-2:s3:action/GetObject&Bucket={bucket}&Key={key}`
   or `arn:aws:apigateway:us-west-2:s3:path/{bucket}/{key}`
-
-### region
-
-`string`
-
-
 
 ## Outputs
 

--- a/docs/resources/aws/apigateway_method.md
+++ b/docs/resources/aws/apigateway_method.md
@@ -86,7 +86,7 @@ method in [PetStore](https://petstore-demo-endpoint.execute-api.com/petstore/pet
 
 `string`
 
-
+The region the API Gateway is deployed to.
 
 ### request_models
 

--- a/docs/resources/aws/apigateway_resource.md
+++ b/docs/resources/aws/apigateway_resource.md
@@ -12,8 +12,8 @@ API.
 | --- | ---- | ---- | -------: |
 | input | [`parent_id`](#parent_id) | `string` | required |
 | input | [`path_part`](#path_part) | `string` | required |
-| input | [`rest_api_id`](#rest_api_id) | `string` | required |
 | input | [`region`](#region) | `string` | required |
+| input | [`rest_api_id`](#rest_api_id) | `string` | required |
 | output | [`id`](#id) | `string` ||
 | output | [`path`](#path) | `string` ||
 
@@ -32,17 +32,17 @@ The parent resource's identifier.
 
 The last path segment for this resource.
 
+### region
+
+`string`
+
+The region the API Gateway is deployed to.
+
 ### rest_api_id
 
 `string`
 
 The string identifier of the associated RestApi.
-
-### region
-
-`string`
-
-
 
 ## Outputs
 

--- a/docs/resources/aws/apigateway_rest_api.md
+++ b/docs/resources/aws/apigateway_rest_api.md
@@ -90,7 +90,7 @@ of the caller and Method
 
 `string`
 
-The region to deploy the RestApi in.
+The region the API Gateway is deployed to.
 
 ### version
 

--- a/docs/resources/aws/apigateway_stage.md
+++ b/docs/resources/aws/apigateway_stage.md
@@ -15,17 +15,19 @@
 | input | [`deployment_id`](#deployment_id) | `string` | required |
 | input | [`description`](#description) | `string` |  |
 | input | [`deployment_version`](#deployment_version) | `string` |  |
+| input | [`region`](#region) | `string` | required |
 | input | [`rest_api_id`](#rest_api_id) | `string` | required |
 | input | [`stage_name`](#stage_name) | `string` | required |
 | input | [`tags`](#tags) | `map` |  |
 | input | [`tracing_enabled`](#tracing_enabled) | `bool` |  |
 | input | [`variables`](#variables) | `map` |  |
-| input | [`region`](#region) | `string` | required |
 | output | [`access_log_settings`](#access_log_settings) | `AccessLogSettings` ||
 | output | [`cache_cluster_status`](#cache_cluster_status) | `string` ||
 | output | [`client_certificate_id`](#client_certificate_id) | `string` ||
 | output | [`created_date`](#created_date) | `time` ||
 | output | [`last_updated_date`](#last_updated_date) | `time` ||
+| output | [`method_settings`](#method_settings) | `map` ||
+| output | [`web_acl_arn`](#web_acl_arn) | `string` ||
 
 
 ## Inputs
@@ -78,6 +80,12 @@ The description of the Stage resource.
 
 The version of the associated API documentation.
 
+### region
+
+`string`
+
+The region the API Gateway is deployed to.
+
 ### rest_api_id
 
 `string`
@@ -112,12 +120,6 @@ A map that defines the stage variables for the new Stage resource. Variable
 names can have alphanumeric and underscore characters, and the values must
 match `[A-Za-z0-9-._~:/?#&=,]+`.
 
-### region
-
-`string`
-
-The region API Gateway is deployed to.
-
 ## Outputs
 
 ### access_log_settings
@@ -151,3 +153,16 @@ The timestamp when the stage was created.
 `time`
 
 The timestamp when the stage last updated.
+### method_settings
+
+`map`
+
+A map that defines the method settings for a Stage resource. Keys (designated
+as /{method_setting_key below) are method paths defined as {resource_path}/{http_method}
+for an individual method override, or /\*/\* for overriding all methods in
+the stage.
+### web_acl_arn
+
+`string`
+
+The ARN of the WebAcl associated with the Stage.

--- a/docs/resources/aws/lambda_function.md
+++ b/docs/resources/aws/lambda_function.md
@@ -30,9 +30,9 @@ https://aws.amazon.com/lambda/
 | input | [`layers`](#layers) | `array` |  |
 | input | [`memory_size`](#memory_size) | `int64` |  |
 | input | [`publish`](#publish) | `bool` |  |
+| input | [`region`](#region) | `string` | required |
 | input | [`role`](#role) | `string` | required |
 | input | [`runtime`](#runtime) | `string` | required |
-| input | [`region`](#region) | `string` | required |
 | input | [`tags`](#tags) | `map` |  |
 | input | [`timeout`](#timeout) | `int64` |  |
 | input | [`tracing_config`](#tracing_config) | `struct` |  |
@@ -121,6 +121,12 @@ is 128 MB. The value must be a multiple of 64 MB.
 Set to true to publish the first version of the function during
 creation.
 
+### region
+
+`string`
+
+Region to run the Lambda function in.
+
 ### role
 
 `string`
@@ -153,12 +159,6 @@ Allowed values:
 
 
 > TODO: enum
-### region
-
-`string`
-
-The region the function should run in.
-
 ### tags
 
 `optional map`

--- a/docs/resources/aws/lambda_permission.md
+++ b/docs/resources/aws/lambda_permission.md
@@ -9,11 +9,11 @@ LambdaInvokePermission sets permissions on a Lambda function.
 
 | i/o | name | type | required |
 | --- | ---- | ---- | -------: |
-| input | [`region`](#region) | `string` | required |
 | input | [`action`](#action) | `string` | required |
 | input | [`event_source_token`](#event_source_token) | `string` |  |
 | input | [`function_name`](#function_name) | `string` | required |
 | input | [`principal`](#principal) | `string` | required |
+| input | [`region`](#region) | `string` | required |
 | input | [`qualifier`](#qualifier) | `string` |  |
 | input | [`revision_id`](#revision_id) | `string` |  |
 | input | [`service_account`](#service_account) | `string` |  |
@@ -23,12 +23,6 @@ LambdaInvokePermission sets permissions on a Lambda function.
 
 
 ## Inputs
-
-### region
-
-`string`
-
-The region the function is in.
 
 ### action
 
@@ -70,6 +64,12 @@ AWS service (e.g. `s3.amazonaws.com` or `sns.amazonaws.com`) for service
 triggers, or an account ID for cross-account access. If you specify a
 service as a principal, use the SourceArn parameter to limit who can
 invoke the function through that service.
+
+### region
+
+`string`
+
+Region the Lambda function has been deployed to.
 
 ### qualifier
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/func/func
 
 require (
 	github.com/agext/levenshtein v1.2.1
-	github.com/aws/aws-sdk-go-v2 v0.7.0
+	github.com/aws/aws-sdk-go-v2 v0.8.0
 	github.com/cenkalti/backoff v2.1.1+incompatible
 	github.com/fatih/structtag v1.0.0
 	github.com/golang/protobuf v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
-github.com/aws/aws-sdk-go-v2 v0.7.0 h1:a5xRI/tBmUFKuAA0SOyEY2P1YhQb+jVOEI9P/7KfrP0=
-github.com/aws/aws-sdk-go-v2 v0.7.0/go.mod h1:17MaCZ9g0q5BIMxwzRQeiv8M3c8+W7iuBnlWAEprcxE=
+github.com/aws/aws-sdk-go-v2 v0.8.0 h1:IyCzxvwRVe2ehXfi7YMsVxaVU6JvaH58ZO7uPFS3HlY=
+github.com/aws/aws-sdk-go-v2 v0.8.0/go.mod h1:sa1GePZ/LfBGI4dSq30f6uR4Tthll8axxtEPvlpXZ8U=
 github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e h1:D64GF/Xr5zSUnM3q1Jylzo4sK7szhP/ON+nb2DB5XJA=
 github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e/go.mod h1:N+BjUcTjSxc2mtRGSCPsat1kze3CUtvJN3/jTXlp29k=
 github.com/cenkalti/backoff v2.1.1+incompatible h1:tKJnvO2kl0zmb/jA5UKAt4VoEVw1qxKWjE/Bpp46npY=
@@ -23,7 +23,6 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/gucumber/gucumber v0.0.0-20180127021336-7d5c79e832a2/go.mod h1:YbdHRK9ViqwGMS0rtRY+1I6faHvVyyurKPIPwifihxI=
 github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v0.0.0-20180717150148-3d5d8f294aa0/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/hcl2 v0.0.0-20190418145123-f7764c69544d h1:vyEKI+SsDhMuOPzaNyorM9SJJYdkELPqjWOd6bnLL0w=
@@ -58,7 +57,6 @@ github.com/segmentio/ksuid v1.0.2 h1:9yBfKyw4ECGTdALaF09Snw3sLJmYIX6AbPJrAy6MrDc
 github.com/segmentio/ksuid v1.0.2/go.mod h1:BXuJDr2byAiHuQaQtSKoXh1J0YmUDurywOXgB2w+OSU=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/shiena/ansicolor v0.0.0-20151119151921-a422bbe96644/go.mod h1:nkxAfR/5quYxwPZhyDxgasBMnRtBZd0FCEpawpjMUFg=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.2 h1:Fy0orTDgHdbnzHcsOgfCN4LtHf0ec3wwtiwJqwvf3Gc=

--- a/provider/aws/apigateway_deployment.go
+++ b/provider/aws/apigateway_deployment.go
@@ -156,8 +156,7 @@ func (p *APIGatewayDeployment) Create(ctx context.Context, r *resource.CreateReq
 	input.Variables["func_change_trigger_hash"] = hex.EncodeToString(sha.Sum(nil))
 
 	req := svc.CreateDeploymentRequest(input)
-	req.SetContext(ctx)
-	resp, err := req.Send()
+	resp, err := req.Send(ctx)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == apigateway.ErrCodeBadRequestException {
@@ -195,8 +194,7 @@ func (p *APIGatewayDeployment) Delete(ctx context.Context, r *resource.DeleteReq
 		RestApiId:    aws.String(p.RestAPIID),
 		DeploymentId: aws.String(p.ID),
 	})
-	req.SetContext(ctx)
-	_, err = req.Send()
+	_, err = req.Send(ctx)
 	return err
 }
 

--- a/provider/aws/apigateway_deployment_stage.go
+++ b/provider/aws/apigateway_deployment_stage.go
@@ -237,8 +237,7 @@ func (p *APIGatewayStage) Create(ctx context.Context, r *resource.CreateRequest)
 	}
 
 	req := svc.CreateStageRequest(input)
-	req.SetContext(ctx)
-	resp, err := req.Send()
+	resp, err := req.Send(ctx)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == apigateway.ErrCodeBadRequestException {
@@ -264,8 +263,7 @@ func (p *APIGatewayStage) Delete(ctx context.Context, r *resource.DeleteRequest)
 		RestApiId: aws.String(p.RestAPIID),
 		StageName: aws.String(p.StageName),
 	})
-	req.SetContext(ctx)
-	_, err = req.Send()
+	_, err = req.Send(ctx)
 	return err
 }
 
@@ -321,8 +319,7 @@ func (p *APIGatewayStage) Update(ctx context.Context, r *resource.UpdateRequest)
 		RestApiId:       aws.String(p.RestAPIID),
 		StageName:       aws.String(p.StageName),
 	})
-	req.SetContext(ctx)
-	resp, err := req.Send()
+	resp, err := req.Send(ctx)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == apigateway.ErrCodeBadRequestException {

--- a/provider/aws/apigateway_deployment_stage.go
+++ b/provider/aws/apigateway_deployment_stage.go
@@ -10,10 +10,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/awserr"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	"github.com/aws/aws-sdk-go-v2/service/apigateway/apigatewayiface"
 	"github.com/cenkalti/backoff"
 	"github.com/func/func/provider/aws/internal/apigatewaypatch"
-	"github.com/func/func/provider/aws/internal/config"
 	"github.com/func/func/resource"
 	"github.com/pkg/errors"
 )
@@ -51,6 +49,9 @@ type APIGatewayStage struct { // nolint: malign
 	// The version of the associated API documentation.
 	DocumentationVersion *string `input:"deployment_version"`
 
+	// The region the API Gateway is deployed to.
+	Region string `input:"region"`
+
 	// The string identifier of the associated RestApi.
 	RestAPIID string `input:"rest_api_id"`
 
@@ -69,9 +70,6 @@ type APIGatewayStage struct { // nolint: malign
 	// names can have alphanumeric and underscore characters, and the values must
 	// match `[A-Za-z0-9-._~:/?#&=,]+`.
 	Variables *map[string]string `input:"variables"`
-
-	// The region API Gateway is deployed to.
-	Region string `input:"region"`
 
 	// Outputs
 
@@ -104,8 +102,6 @@ type APIGatewayStage struct { // nolint: malign
 
 	// The ARN of the WebAcl associated with the Stage.
 	WebACLARN *string `output:"web_acl_arn"`
-
-	svc apigatewayiface.APIGatewayAPI
 }
 
 // APIGatewayCanarySettings contains settings for canary deployment.
@@ -197,7 +193,7 @@ func (p *APIGatewayStage) Type() string { return "aws_apigateway_stage" }
 
 // Create creates a new deployment.
 func (p *APIGatewayStage) Create(ctx context.Context, r *resource.CreateRequest) error {
-	svc, err := p.service(r.Auth)
+	svc, err := apigatewayService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
@@ -259,7 +255,7 @@ func (p *APIGatewayStage) Create(ctx context.Context, r *resource.CreateRequest)
 
 // Delete removes a deployment.
 func (p *APIGatewayStage) Delete(ctx context.Context, r *resource.DeleteRequest) error {
-	svc, err := p.service(r.Auth)
+	svc, err := apigatewayService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
@@ -315,7 +311,7 @@ func (p *APIGatewayStage) Update(ctx context.Context, r *resource.UpdateRequest)
 		return nil
 	}
 
-	svc, err := p.service(r.Auth)
+	svc, err := apigatewayService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
@@ -339,17 +335,6 @@ func (p *APIGatewayStage) Update(ctx context.Context, r *resource.UpdateRequest)
 	p.setFromResp(resp)
 
 	return nil
-}
-
-func (p *APIGatewayStage) service(auth resource.AuthProvider) (apigatewayiface.APIGatewayAPI, error) {
-	if p.svc == nil {
-		cfg, err := config.WithRegion(auth, p.Region)
-		if err != nil {
-			return nil, errors.Wrap(err, "get aws config")
-		}
-		p.svc = apigateway.New(cfg)
-	}
-	return p.svc, nil
 }
 
 func (p *APIGatewayStage) setFromResp(resp *apigateway.UpdateStageOutput) {

--- a/provider/aws/apigateway_integration.go
+++ b/provider/aws/apigateway_integration.go
@@ -12,10 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/awserr"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	"github.com/aws/aws-sdk-go-v2/service/apigateway/apigatewayiface"
 	"github.com/cenkalti/backoff"
 	"github.com/func/func/provider/aws/internal/apigatewaypatch"
-	"github.com/func/func/provider/aws/internal/config"
 	"github.com/func/func/resource"
 	"github.com/pkg/errors"
 )
@@ -86,6 +84,9 @@ type APIGatewayIntegration struct {
 	//   types mapped to templates. However if there is at least one content type
 	//   defined, unmapped content types will be rejected with the same 415 response.
 	PassthroughBehavior *string `input:"passthrough_behavior"`
+
+	// The region the API Gateway is deployed to.
+	Region string `input:"region"`
 
 	// A key-value map specifying request parameters that are passed from the
 	// method request to the back end. The key is an integration request
@@ -169,16 +170,12 @@ type APIGatewayIntegration struct {
 	//   or `arn:aws:apigateway:us-west-2:s3:path/{bucket}/{key}`
 	URI *string `input:"uri"`
 
-	Region string `input:"region"`
-
 	// Outputs
 
 	// Specifies the integration's responses.
 	//
 	// The key in the map is the HTTP status code.
 	IntegrationResponses map[string]APIGatewayIntegrationResponse `output:"integration_responses"`
-
-	svc apigatewayiface.APIGatewayAPI
 }
 
 // APIGatewayIntegrationResponse is the output from an integration for a
@@ -238,7 +235,7 @@ func (p *APIGatewayIntegration) Type() string { return "aws_apigateway_integrati
 
 // Create creates a new resource.
 func (p *APIGatewayIntegration) Create(ctx context.Context, r *resource.CreateRequest) error {
-	svc, err := p.service(r.Auth)
+	svc, err := apigatewayService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
@@ -303,7 +300,7 @@ func (p *APIGatewayIntegration) Create(ctx context.Context, r *resource.CreateRe
 
 // Delete removes a resource.
 func (p *APIGatewayIntegration) Delete(ctx context.Context, r *resource.DeleteRequest) error {
-	svc, err := p.service(r.Auth)
+	svc, err := apigatewayService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
@@ -384,7 +381,7 @@ func (p *APIGatewayIntegration) Update(ctx context.Context, r *resource.UpdateRe
 		return nil
 	}
 
-	svc, err := p.service(r.Auth)
+	svc, err := apigatewayService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
@@ -406,15 +403,4 @@ func (p *APIGatewayIntegration) Update(ctx context.Context, r *resource.UpdateRe
 	}
 
 	return nil
-}
-
-func (p *APIGatewayIntegration) service(auth resource.AuthProvider) (apigatewayiface.APIGatewayAPI, error) {
-	if p.svc == nil {
-		cfg, err := config.WithRegion(auth, p.Region)
-		if err != nil {
-			return nil, errors.Wrap(err, "get aws config")
-		}
-		p.svc = apigateway.New(cfg)
-	}
-	return p.svc, nil
 }

--- a/provider/aws/apigateway_integration.go
+++ b/provider/aws/apigateway_integration.go
@@ -273,8 +273,7 @@ func (p *APIGatewayIntegration) Create(ctx context.Context, r *resource.CreateRe
 	}
 
 	req := svc.PutIntegrationRequest(input)
-	req.SetContext(ctx)
-	resp, err := req.Send()
+	resp, err := req.Send(ctx)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == apigateway.ErrCodeBadRequestException || aerr.Code() == "ValidationException" {
@@ -310,8 +309,7 @@ func (p *APIGatewayIntegration) Delete(ctx context.Context, r *resource.DeleteRe
 		ResourceId: aws.String(p.ResourceID),
 		RestApiId:  aws.String(p.RestAPIID),
 	})
-	req.SetContext(ctx)
-	if _, err := req.Send(); err != nil {
+	if _, err := req.Send(ctx); err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == apigateway.ErrCodeNotFoundException {
 				return nil
@@ -392,8 +390,7 @@ func (p *APIGatewayIntegration) Update(ctx context.Context, r *resource.UpdateRe
 		RestApiId:       aws.String(p.RestAPIID),
 		PatchOperations: ops,
 	})
-	req.SetContext(ctx)
-	if _, err := req.Send(); err != nil {
+	if _, err := req.Send(ctx); err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == apigateway.ErrCodeBadRequestException {
 				return backoff.Permanent(err)

--- a/provider/aws/apigateway_method.go
+++ b/provider/aws/apigateway_method.go
@@ -122,8 +122,7 @@ func (p *APIGatewayMethod) Create(ctx context.Context, r *resource.CreateRequest
 	}
 
 	req := svc.PutMethodRequest(input)
-	req.SetContext(ctx)
-	resp, err := req.Send()
+	resp, err := req.Send(ctx)
 	if err != nil {
 		return err
 	}
@@ -147,8 +146,7 @@ func (p *APIGatewayMethod) Delete(ctx context.Context, r *resource.DeleteRequest
 		ResourceId: aws.String(p.ResourceID),
 		RestApiId:  aws.String(p.RestAPIID),
 	})
-	req.SetContext(ctx)
-	if _, err := req.Send(); err != nil {
+	if _, err := req.Send(ctx); err != nil {
 		return err
 	}
 
@@ -205,8 +203,7 @@ func (p *APIGatewayMethod) Update(ctx context.Context, r *resource.UpdateRequest
 		RestApiId:       aws.String(p.RestAPIID),
 		PatchOperations: ops,
 	})
-	req.SetContext(ctx)
-	if _, err := req.Send(); err != nil {
+	if _, err := req.Send(ctx); err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == "SerializationError" {
 				return backoff.Permanent(err)

--- a/provider/aws/apigateway_resource.go
+++ b/provider/aws/apigateway_resource.go
@@ -56,8 +56,7 @@ func (p *APIGatewayResource) Create(ctx context.Context, r *resource.CreateReque
 	}
 
 	req := svc.CreateResourceRequest(input)
-	req.SetContext(ctx)
-	resp, err := req.Send()
+	resp, err := req.Send(ctx)
 	if err != nil {
 		return err
 	}
@@ -87,8 +86,7 @@ func (p *APIGatewayResource) Delete(ctx context.Context, r *resource.DeleteReque
 	}
 
 	req := svc.DeleteResourceRequest(input)
-	req.SetContext(ctx)
-	if _, err := req.Send(); err != nil {
+	if _, err := req.Send(ctx); err != nil {
 		return err
 	}
 
@@ -123,8 +121,7 @@ func (p *APIGatewayResource) Update(ctx context.Context, r *resource.UpdateReque
 	}
 
 	req := svc.UpdateResourceRequest(input)
-	req.SetContext(ctx)
-	if _, err := req.Send(); err != nil {
+	if _, err := req.Send(ctx); err != nil {
 		return err
 	}
 

--- a/provider/aws/apigateway_resource.go
+++ b/provider/aws/apigateway_resource.go
@@ -8,9 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	"github.com/aws/aws-sdk-go-v2/service/apigateway/apigatewayiface"
 	"github.com/func/func/provider/aws/internal/apigatewaypatch"
-	"github.com/func/func/provider/aws/internal/config"
 	"github.com/func/func/resource"
 	"github.com/pkg/errors"
 )
@@ -18,16 +16,19 @@ import (
 // APIGatewayResource provides a resource (GET /, POST /user etc) in a REST
 // API.
 type APIGatewayResource struct {
+	// Inputs
+
 	// The parent resource's identifier.
 	ParentID string `input:"parent_id"`
 
 	// The last path segment for this resource.
 	PathPart string `input:"path_part"`
 
+	// The region the API Gateway is deployed to.
+	Region string `input:"region"`
+
 	// The string identifier of the associated RestApi.
 	RestAPIID string `input:"rest_api_id"`
-
-	Region string `input:"region"`
 
 	// Outputs
 
@@ -36,8 +37,6 @@ type APIGatewayResource struct {
 
 	// The full path for this resource.
 	Path string `output:"path"`
-
-	svc apigatewayiface.APIGatewayAPI
 }
 
 // Type returns the resource type of a apigateway resource.
@@ -45,7 +44,7 @@ func (p *APIGatewayResource) Type() string { return "aws_apigateway_resource" }
 
 // Create creates a new resource.
 func (p *APIGatewayResource) Create(ctx context.Context, r *resource.CreateRequest) error {
-	svc, err := p.service(r.Auth)
+	svc, err := apigatewayService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
@@ -77,7 +76,7 @@ func (p *APIGatewayResource) Create(ctx context.Context, r *resource.CreateReque
 
 // Delete removes a resource.
 func (p *APIGatewayResource) Delete(ctx context.Context, r *resource.DeleteRequest) error {
-	svc, err := p.service(r.Auth)
+	svc, err := apigatewayService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
@@ -112,7 +111,7 @@ func (p *APIGatewayResource) Update(ctx context.Context, r *resource.UpdateReque
 		return nil
 	}
 
-	svc, err := p.service(r.Auth)
+	svc, err := apigatewayService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
@@ -130,15 +129,4 @@ func (p *APIGatewayResource) Update(ctx context.Context, r *resource.UpdateReque
 	}
 
 	return nil
-}
-
-func (p *APIGatewayResource) service(auth resource.AuthProvider) (apigatewayiface.APIGatewayAPI, error) {
-	if p.svc == nil {
-		cfg, err := config.WithRegion(auth, p.Region)
-		if err != nil {
-			return nil, errors.Wrap(err, "get aws config")
-		}
-		p.svc = apigateway.New(cfg)
-	}
-	return p.svc, nil
 }

--- a/provider/aws/apigateway_rest_api.go
+++ b/provider/aws/apigateway_rest_api.go
@@ -120,8 +120,7 @@ func (p *APIGatewayRestAPI) Create(ctx context.Context, r *resource.CreateReques
 	}
 
 	req := svc.CreateRestApiRequest(input)
-	req.SetContext(ctx)
-	resp, err := req.Send()
+	resp, err := req.Send(ctx)
 	if err != nil {
 		return err
 	}
@@ -133,7 +132,7 @@ func (p *APIGatewayRestAPI) Create(ctx context.Context, r *resource.CreateReques
 	rootReq := svc.GetResourcesRequest(&apigateway.GetResourcesInput{
 		RestApiId: resp.Id,
 	})
-	rootRes, err := rootReq.Send()
+	rootRes, err := rootReq.Send(ctx)
 	if err != nil {
 		return errors.Wrap(err, "read root resource")
 	}
@@ -158,8 +157,7 @@ func (p *APIGatewayRestAPI) Delete(ctx context.Context, r *resource.DeleteReques
 	}
 
 	req := svc.DeleteRestApiRequest(input)
-	req.SetContext(ctx)
-	if _, err := req.Send(); err != nil {
+	if _, err := req.Send(ctx); err != nil {
 		return err
 	}
 
@@ -240,8 +238,7 @@ func (p *APIGatewayRestAPI) Update(ctx context.Context, r *resource.UpdateReques
 	}
 
 	req := svc.UpdateRestApiRequest(input)
-	req.SetContext(ctx)
-	if _, err := req.Send(); err != nil {
+	if _, err := req.Send(ctx); err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == apigateway.ErrCodeBadRequestException {
 				if strings.Contains(aerr.Message(), "update is still in progress") {

--- a/provider/aws/iam_policy.go
+++ b/provider/aws/iam_policy.go
@@ -114,8 +114,7 @@ func (p *IAMPolicy) Create(ctx context.Context, r *resource.CreateRequest) error
 		PolicyDocument: aws.String(p.PolicyDocument),
 		PolicyName:     aws.String(p.PolicyName),
 	})
-	req.SetContext(ctx)
-	resp, err := req.Send()
+	resp, err := req.Send(ctx)
 	if err != nil {
 		return errors.Wrap(err, "send request")
 	}
@@ -142,8 +141,7 @@ func (p *IAMPolicy) Delete(ctx context.Context, r *resource.DeleteRequest) error
 	req := svc.DeletePolicyRequest(&iam.DeletePolicyInput{
 		PolicyArn: aws.String(p.ARN),
 	})
-	req.SetContext(ctx)
-	if _, err := req.Send(); err != nil {
+	if _, err := req.Send(ctx); err != nil {
 		return errors.Wrap(err, "send request")
 	}
 

--- a/provider/aws/iam_policy.go
+++ b/provider/aws/iam_policy.go
@@ -9,9 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
-	"github.com/aws/aws-sdk-go-v2/service/iam/iamiface"
 	"github.com/cenkalti/backoff"
-	"github.com/func/func/provider/aws/internal/config"
 	"github.com/func/func/resource"
 	"github.com/pkg/errors"
 )
@@ -20,6 +18,8 @@ import (
 //
 // The policy can be attached to a role using `aws_iam_role_policy_attachment`.
 type IAMPolicy struct {
+	// Inputs
+
 	// A friendly description of the policy.
 	//
 	// Typically used to store information about the permissions defined in the
@@ -44,6 +44,12 @@ type IAMPolicy struct {
 
 	// The friendly name of the policy.
 	PolicyName string `input:"policy_name"`
+
+	// Region to use for IAM API calls.
+	//
+	// IAM is global so the calls are not regional but the Region will specify
+	// which region the API calls are sent to.
+	Region *string
 
 	// Outputs
 
@@ -90,8 +96,6 @@ type IAMPolicy struct {
 	// field contains the date and time when the most recent policy version was
 	// created.
 	UpdateDate time.Time `output:"update_date"`
-
-	svc iamiface.IAMAPI
 }
 
 // Type returns the type name for an AWS IAM policy resource.
@@ -99,7 +103,7 @@ func (p *IAMPolicy) Type() string { return "aws_iam_policy" }
 
 // Create creates a new IAM policy.
 func (p *IAMPolicy) Create(ctx context.Context, r *resource.CreateRequest) error {
-	svc, err := p.service(r.Auth)
+	svc, err := iamService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
@@ -130,7 +134,7 @@ func (p *IAMPolicy) Create(ctx context.Context, r *resource.CreateRequest) error
 
 // Delete deletes the IAM policy.
 func (p *IAMPolicy) Delete(ctx context.Context, r *resource.DeleteRequest) error {
-	svc, err := p.service(r.Auth)
+	svc, err := iamService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
@@ -152,15 +156,4 @@ func (p *IAMPolicy) Update(ctx context.Context, r *resource.UpdateRequest) error
 	// problems in case the policy is attached somewhere. For now, return an
 	// error instead.
 	return backoff.Permanent(errors.New("policy cannot be updated"))
-}
-
-func (p *IAMPolicy) service(auth resource.AuthProvider) (iamiface.IAMAPI, error) {
-	if p.svc == nil {
-		cfg, err := config.DefaultRegion(auth)
-		if err != nil {
-			return nil, errors.Wrap(err, "get aws config")
-		}
-		p.svc = iam.New(cfg)
-	}
-	return p.svc, nil
 }

--- a/provider/aws/iam_role.go
+++ b/provider/aws/iam_role.go
@@ -126,8 +126,7 @@ func (p *IAMRole) Create(ctx context.Context, r *resource.CreateRequest) error {
 		PermissionsBoundary:      p.PermissionsBoundary,
 		RoleName:                 aws.String(p.RoleName),
 	})
-	req.SetContext(ctx)
-	res, err := req.Send()
+	res, err := req.Send(ctx)
 	if err != nil {
 		return errors.Wrap(err, "send request")
 	}
@@ -149,8 +148,7 @@ func (p *IAMRole) Delete(ctx context.Context, r *resource.DeleteRequest) error {
 	req := svc.DeleteRoleRequest(&iam.DeleteRoleInput{
 		RoleName: aws.String(p.RoleName),
 	})
-	req.SetContext(ctx)
-	if _, err := req.Send(); err != nil {
+	if _, err := req.Send(ctx); err != nil {
 		return errors.Wrap(err, "send request")
 	}
 
@@ -169,8 +167,7 @@ func (p *IAMRole) Update(ctx context.Context, r *resource.UpdateRequest) error {
 		Description:        p.Description,
 		MaxSessionDuration: p.MaxSessionDuration,
 	})
-	req.SetContext(ctx)
-	if _, err := req.Send(); err != nil {
+	if _, err := req.Send(ctx); err != nil {
 		return errors.Wrap(err, "send request")
 	}
 

--- a/provider/aws/iam_role_policy.go
+++ b/provider/aws/iam_role_policy.go
@@ -49,8 +49,7 @@ func (p *IAMRolePolicy) Create(ctx context.Context, r *resource.CreateRequest) e
 		PolicyName:     aws.String(p.PolicyName),
 		RoleName:       aws.String(p.RoleName),
 	})
-	req.SetContext(ctx)
-	if _, err := req.Send(); err != nil {
+	if _, err := req.Send(ctx); err != nil {
 		return errors.Wrap(err, "send request")
 	}
 
@@ -70,8 +69,7 @@ func (p *IAMRolePolicy) Delete(ctx context.Context, r *resource.DeleteRequest) e
 		PolicyName: aws.String(p.PolicyName),
 		RoleName:   aws.String(p.RoleName),
 	})
-	req.SetContext(ctx)
-	if _, err := req.Send(); err != nil {
+	if _, err := req.Send(ctx); err != nil {
 		return errors.Wrap(err, "send request")
 	}
 

--- a/provider/aws/iam_role_policy.go
+++ b/provider/aws/iam_role_policy.go
@@ -8,34 +8,38 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
-	"github.com/aws/aws-sdk-go-v2/service/iam/iamiface"
-	"github.com/func/func/provider/aws/internal/config"
 	"github.com/func/func/resource"
 	"github.com/pkg/errors"
 )
 
 // IAMRolePolicy is an inline role policy, attached to a role.
 type IAMRolePolicy struct {
+	// Inputs
+
 	// The policy document.
 	PolicyDocument string `input:"policy_document"`
 
 	// The name of the policy document.
 	PolicyName string `input:"policy_name"`
 
+	// Region to use for IAM API calls.
+	//
+	// IAM is global so the calls are not regional but the Region will specify
+	// which region the API calls are sent to.
+	Region *string
+
 	// The name of the role to associate the policy with.
 	RoleName string `input:"role_name"`
 
 	// No outputs
-
-	svc iamiface.IAMAPI
 }
 
 // Type returns the type name for an AWS IAM role policy resource.
-func (p *IAMRolePolicy) Type() string { return "aws_iam_role_policy" }
+func (IAMRolePolicy) Type() string { return "aws_iam_role_policy" }
 
 // Create attaches an inline role policy to and IAM role.
 func (p *IAMRolePolicy) Create(ctx context.Context, r *resource.CreateRequest) error {
-	svc, err := p.service(r.Auth)
+	svc, err := iamService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
@@ -57,7 +61,7 @@ func (p *IAMRolePolicy) Create(ctx context.Context, r *resource.CreateRequest) e
 
 // Delete removes an inline role policy from an IAM role.
 func (p *IAMRolePolicy) Delete(ctx context.Context, r *resource.DeleteRequest) error {
-	svc, err := p.service(r.Auth)
+	svc, err := iamService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
@@ -90,15 +94,4 @@ func (p *IAMRolePolicy) Update(ctx context.Context, r *resource.UpdateRequest) e
 	}
 
 	return nil
-}
-
-func (p *IAMRolePolicy) service(auth resource.AuthProvider) (iamiface.IAMAPI, error) {
-	if p.svc == nil {
-		cfg, err := config.DefaultRegion(auth)
-		if err != nil {
-			return nil, errors.Wrap(err, "get aws config")
-		}
-		p.svc = iam.New(cfg)
-	}
-	return p.svc, nil
 }

--- a/provider/aws/iam_role_policy_attachment.go
+++ b/provider/aws/iam_role_policy_attachment.go
@@ -55,8 +55,7 @@ func (p *IAMRolePolicyAttachment) Create(ctx context.Context, r *resource.Create
 		PolicyArn: aws.String(p.PolicyARN),
 		RoleName:  aws.String(p.RoleName),
 	})
-	req.SetContext(ctx)
-	if _, err := req.Send(); err != nil {
+	if _, err := req.Send(ctx); err != nil {
 		return errors.Wrap(err, "send request")
 	}
 
@@ -76,8 +75,7 @@ func (p *IAMRolePolicyAttachment) Delete(ctx context.Context, r *resource.Delete
 		PolicyArn: aws.String(p.PolicyARN),
 		RoleName:  aws.String(p.RoleName),
 	})
-	req.SetContext(ctx)
-	if _, err := req.Send(); err != nil {
+	if _, err := req.Send(ctx); err != nil {
 		return errors.Wrap(err, "send request")
 	}
 

--- a/provider/aws/lambda.go
+++ b/provider/aws/lambda.go
@@ -241,8 +241,7 @@ func (p *LambdaFunction) Create(ctx context.Context, r *resource.CreateRequest) 
 	}
 
 	req := svc.CreateFunctionRequest(input)
-	req.SetContext(ctx)
-	resp, err := req.Send()
+	resp, err := req.Send(ctx)
 	if err != nil {
 		return err
 	}
@@ -264,8 +263,7 @@ func (p *LambdaFunction) Delete(ctx context.Context, r *resource.DeleteRequest) 
 	req := svc.DeleteFunctionRequest(&lambda.DeleteFunctionInput{
 		FunctionName: aws.String(p.FunctionArn),
 	})
-	req.SetContext(ctx)
-	_, err = req.Send()
+	_, err = req.Send(ctx)
 	return err
 }
 
@@ -312,8 +310,7 @@ func (p *LambdaFunction) updateCode(ctx context.Context, svc lambdaiface.LambdaA
 		FunctionName: aws.String(p.FunctionName),
 		ZipFile:      zip.Bytes(),
 	})
-	req.SetContext(ctx)
-	resp, err := req.Send()
+	resp, err := req.Send(ctx)
 	if err != nil {
 		return errors.Wrap(err, "send request")
 	}
@@ -360,8 +357,7 @@ func (p *LambdaFunction) updateConfig(ctx context.Context, svc lambdaiface.Lambd
 	}
 
 	req := svc.UpdateFunctionConfigurationRequest(input)
-	req.SetContext(ctx)
-	resp, err := req.Send()
+	resp, err := req.Send(ctx)
 	if err != nil {
 		return errors.Wrap(err, "send request")
 	}

--- a/provider/aws/lambda.go
+++ b/provider/aws/lambda.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/lambda/lambdaiface"
-	"github.com/func/func/provider/aws/internal/config"
 	"github.com/func/func/resource"
 	"github.com/func/func/source/convert"
 	"github.com/pkg/errors"
@@ -88,6 +87,9 @@ type LambdaFunction struct {
 	// creation.
 	Publish *bool `input:"publish"`
 
+	// Region to run the Lambda function in.
+	Region string `input:"region"`
+
 	// The Amazon Resource Name (ARN) of the function's execution role
 	// (http://docs.aws.amazon.com/lambda/latest/dg/intro-permission-model.html#lambda-intro-execution-role).
 	Role string `input:"role"`
@@ -111,9 +113,6 @@ type LambdaFunction struct {
 	//   - ruby2.5
 	//   - provided
 	Runtime string `input:"runtime"` // TODO: enum
-
-	// The region the function should run in.
-	Region string `input:"region"`
 
 	// The list of tags (key-value pairs) assigned to the new function. For
 	// more information, see
@@ -168,15 +167,13 @@ type LambdaFunction struct {
 
 	// The version of the Lambda function.
 	Version string `output:"version"`
-
-	svc lambdaiface.LambdaAPI
 }
 
 // Type returns the type name for an AWS Lambda function.
-func (l *LambdaFunction) Type() string { return "aws_lambda_function" }
+func (p *LambdaFunction) Type() string { return "aws_lambda_function" }
 
 // Create creates an AWS lambda function.
-func (l *LambdaFunction) Create(ctx context.Context, r *resource.CreateRequest) error {
+func (p *LambdaFunction) Create(ctx context.Context, r *resource.CreateRequest) error {
 	if len(r.Source) == 0 {
 		return errors.New("no source code provided")
 	}
@@ -184,7 +181,7 @@ func (l *LambdaFunction) Create(ctx context.Context, r *resource.CreateRequest) 
 		return errors.New("only one source archive allowed")
 	}
 
-	svc, err := l.service(r.Auth)
+	svc, err := lambdaService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
@@ -205,41 +202,41 @@ func (l *LambdaFunction) Create(ctx context.Context, r *resource.CreateRequest) 
 		Code: &lambda.FunctionCode{
 			ZipFile: zip.Bytes(),
 		},
-		Description:  l.Description,
-		FunctionName: aws.String(l.FunctionName),
-		Handler:      aws.String(l.Handler),
-		KMSKeyArn:    l.KMSKeyArn,
-		MemorySize:   l.MemorySize,
-		Publish:      l.Publish,
-		Role:         aws.String(l.Role),
-		Runtime:      lambda.Runtime(l.Runtime),
-		Timeout:      l.Timeout,
+		Description:  p.Description,
+		FunctionName: aws.String(p.FunctionName),
+		Handler:      aws.String(p.Handler),
+		KMSKeyArn:    p.KMSKeyArn,
+		MemorySize:   p.MemorySize,
+		Publish:      p.Publish,
+		Role:         aws.String(p.Role),
+		Runtime:      lambda.Runtime(p.Runtime),
+		Timeout:      p.Timeout,
 	}
-	if l.DeadLetterConfig != nil {
+	if p.DeadLetterConfig != nil {
 		input.DeadLetterConfig = &lambda.DeadLetterConfig{
-			TargetArn: l.DeadLetterConfig.TargetArn,
+			TargetArn: p.DeadLetterConfig.TargetArn,
 		}
 	}
-	if l.Environment != nil {
+	if p.Environment != nil {
 		input.Environment = &lambda.Environment{
-			Variables: l.Environment.Variables,
+			Variables: p.Environment.Variables,
 		}
 	}
-	if l.Layers != nil {
-		input.Layers = *l.Layers
+	if p.Layers != nil {
+		input.Layers = *p.Layers
 	}
-	if l.Tags != nil {
-		input.Tags = *l.Tags
+	if p.Tags != nil {
+		input.Tags = *p.Tags
 	}
-	if l.TracingConfig != nil {
+	if p.TracingConfig != nil {
 		input.TracingConfig = &lambda.TracingConfig{
-			Mode: lambda.TracingMode(l.TracingConfig.Mode),
+			Mode: lambda.TracingMode(p.TracingConfig.Mode),
 		}
 	}
-	if l.VpcConfig != nil {
+	if p.VpcConfig != nil {
 		input.VpcConfig = &lambda.VpcConfig{
-			SecurityGroupIds: l.VpcConfig.SecurityGroupIDs,
-			SubnetIds:        l.VpcConfig.SubnetIds,
+			SecurityGroupIds: p.VpcConfig.SecurityGroupIDs,
+			SubnetIds:        p.VpcConfig.SubnetIds,
 		}
 	}
 
@@ -252,20 +249,20 @@ func (l *LambdaFunction) Create(ctx context.Context, r *resource.CreateRequest) 
 
 	// OK
 
-	l.setFromResp(resp)
+	p.setFromResp(resp)
 
 	return nil
 }
 
 // Delete deletes the lambda function.
-func (l *LambdaFunction) Delete(ctx context.Context, r *resource.DeleteRequest) error {
-	svc, err := l.service(r.Auth)
+func (p *LambdaFunction) Delete(ctx context.Context, r *resource.DeleteRequest) error {
+	svc, err := lambdaService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
 
 	req := svc.DeleteFunctionRequest(&lambda.DeleteFunctionInput{
-		FunctionName: aws.String(l.FunctionArn),
+		FunctionName: aws.String(p.FunctionArn),
 	})
 	req.SetContext(ctx)
 	_, err = req.Send()
@@ -273,25 +270,25 @@ func (l *LambdaFunction) Delete(ctx context.Context, r *resource.DeleteRequest) 
 }
 
 // Update updates the lambda function.
-func (l *LambdaFunction) Update(ctx context.Context, r *resource.UpdateRequest) error {
-	svc, err := l.service(r.Auth)
+func (p *LambdaFunction) Update(ctx context.Context, r *resource.UpdateRequest) error {
+	svc, err := lambdaService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
 	if r.SourceChanged {
-		if err := l.updateCode(ctx, svc, r); err != nil {
+		if err := p.updateCode(ctx, svc, r); err != nil {
 			return errors.Wrap(err, "update code")
 		}
 	}
 	if r.ConfigChanged {
-		if err := l.updateConfig(ctx, svc); err != nil {
+		if err := p.updateConfig(ctx, svc); err != nil {
 			return errors.Wrap(err, "update config")
 		}
 	}
 	return nil
 }
 
-func (l *LambdaFunction) updateCode(ctx context.Context, svc lambdaiface.LambdaAPI, r *resource.UpdateRequest) error {
+func (p *LambdaFunction) updateCode(ctx context.Context, svc lambdaiface.LambdaAPI, r *resource.UpdateRequest) error {
 	if len(r.Source) == 0 {
 		return errors.New("no source code provided")
 	}
@@ -312,7 +309,7 @@ func (l *LambdaFunction) updateCode(ctx context.Context, svc lambdaiface.LambdaA
 	}
 
 	req := svc.UpdateFunctionCodeRequest(&lambda.UpdateFunctionCodeInput{
-		FunctionName: aws.String(l.FunctionName),
+		FunctionName: aws.String(p.FunctionName),
 		ZipFile:      zip.Bytes(),
 	})
 	req.SetContext(ctx)
@@ -321,44 +318,44 @@ func (l *LambdaFunction) updateCode(ctx context.Context, svc lambdaiface.LambdaA
 		return errors.Wrap(err, "send request")
 	}
 
-	l.setFromResp(resp)
+	p.setFromResp(resp)
 
 	return nil
 }
 
-func (l *LambdaFunction) updateConfig(ctx context.Context, svc lambdaiface.LambdaAPI) error {
+func (p *LambdaFunction) updateConfig(ctx context.Context, svc lambdaiface.LambdaAPI) error {
 	input := &lambda.UpdateFunctionConfigurationInput{
-		Description:  l.Description,
-		FunctionName: aws.String(l.FunctionName),
-		Handler:      aws.String(l.Handler),
-		KMSKeyArn:    l.KMSKeyArn,
-		MemorySize:   l.MemorySize,
-		Role:         aws.String(l.Role),
-		Runtime:      lambda.Runtime(l.Runtime),
-		Timeout:      l.Timeout,
+		Description:  p.Description,
+		FunctionName: aws.String(p.FunctionName),
+		Handler:      aws.String(p.Handler),
+		KMSKeyArn:    p.KMSKeyArn,
+		MemorySize:   p.MemorySize,
+		Role:         aws.String(p.Role),
+		Runtime:      lambda.Runtime(p.Runtime),
+		Timeout:      p.Timeout,
 	}
-	if l.DeadLetterConfig != nil {
+	if p.DeadLetterConfig != nil {
 		input.DeadLetterConfig = &lambda.DeadLetterConfig{
-			TargetArn: l.DeadLetterConfig.TargetArn,
+			TargetArn: p.DeadLetterConfig.TargetArn,
 		}
 	}
-	if l.Environment != nil {
+	if p.Environment != nil {
 		input.Environment = &lambda.Environment{
-			Variables: l.Environment.Variables,
+			Variables: p.Environment.Variables,
 		}
 	}
-	if l.Layers != nil {
-		input.Layers = *l.Layers
+	if p.Layers != nil {
+		input.Layers = *p.Layers
 	}
-	if l.TracingConfig != nil {
+	if p.TracingConfig != nil {
 		input.TracingConfig = &lambda.TracingConfig{
-			Mode: lambda.TracingMode(l.TracingConfig.Mode),
+			Mode: lambda.TracingMode(p.TracingConfig.Mode),
 		}
 	}
-	if l.VpcConfig != nil {
+	if p.VpcConfig != nil {
 		input.VpcConfig = &lambda.VpcConfig{
-			SecurityGroupIds: l.VpcConfig.SecurityGroupIDs,
-			SubnetIds:        l.VpcConfig.SubnetIds,
+			SecurityGroupIds: p.VpcConfig.SecurityGroupIDs,
+			SubnetIds:        p.VpcConfig.SubnetIds,
 		}
 	}
 
@@ -369,33 +366,22 @@ func (l *LambdaFunction) updateConfig(ctx context.Context, svc lambdaiface.Lambd
 		return errors.Wrap(err, "send request")
 	}
 
-	l.setFromResp(resp)
+	p.setFromResp(resp)
 
 	return nil
 }
 
-func (l *LambdaFunction) service(auth resource.AuthProvider) (lambdaiface.LambdaAPI, error) {
-	if l.svc == nil {
-		cfg, err := config.WithRegion(auth, l.Region)
-		if err != nil {
-			return nil, errors.Wrap(err, "get aws config")
-		}
-		l.svc = lambda.New(cfg)
-	}
-	return l.svc, nil
-}
-
-func (l *LambdaFunction) setFromResp(resp *lambda.UpdateFunctionConfigurationOutput) {
-	l.CodeSha256 = *resp.CodeSha256
-	l.CodeSize = *resp.CodeSize
-	l.FunctionArn = *resp.FunctionArn
+func (p *LambdaFunction) setFromResp(resp *lambda.UpdateFunctionConfigurationOutput) {
+	p.CodeSha256 = *resp.CodeSha256
+	p.CodeSize = *resp.CodeSize
+	p.FunctionArn = *resp.FunctionArn
 	t, err := time.Parse(iso8601, *resp.LastModified)
 	if err != nil {
 		log.Printf("Could not parse Lambda modified timestamp %q, falling back to current time", *resp.LastModified)
 		t = time.Now()
 	}
-	l.LastModified = t
-	l.MasterArn = resp.MasterArn
-	l.RevisionID = *resp.RevisionId
-	l.Version = *resp.Version
+	p.LastModified = t
+	p.MasterArn = resp.MasterArn
+	p.RevisionID = *resp.RevisionId
+	p.Version = *resp.Version
 }

--- a/provider/aws/lambda_invoke_permission.go
+++ b/provider/aws/lambda_invoke_permission.go
@@ -108,8 +108,7 @@ func (p *LambdaInvokePermission) Create(ctx context.Context, r *resource.CreateR
 	}
 
 	req := svc.AddPermissionRequest(input)
-	req.SetContext(ctx)
-	resp, err := req.Send()
+	resp, err := req.Send(ctx)
 	if err != nil {
 		return err
 	}
@@ -132,8 +131,7 @@ func (p *LambdaInvokePermission) Delete(ctx context.Context, r *resource.DeleteR
 		RevisionId:   p.RevisionID,
 		StatementId:  aws.String(p.StatementID),
 	})
-	req.SetContext(ctx)
-	_, err = req.Send()
+	_, err = req.Send(ctx)
 	return err
 }
 

--- a/provider/aws/lambda_invoke_permission.go
+++ b/provider/aws/lambda_invoke_permission.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
-	"github.com/aws/aws-sdk-go-v2/service/lambda/lambdaiface"
-	"github.com/func/func/provider/aws/internal/config"
 	"github.com/func/func/resource"
 	"github.com/pkg/errors"
 )
@@ -17,9 +15,6 @@ import (
 // LambdaInvokePermission sets permissions on a Lambda function.
 type LambdaInvokePermission struct {
 	// Inputs
-
-	// The region the function is in.
-	Region string `input:"region"`
 
 	// The AWS Lambda action you want to allow in this statement. Each Lambda action
 	// is a string starting with lambda: followed by the API name . For example,
@@ -49,6 +44,9 @@ type LambdaInvokePermission struct {
 	// service as a principal, use the SourceArn parameter to limit who can
 	// invoke the function through that service.
 	Principal string `input:"principal"`
+
+	// Region the Lambda function has been deployed to.
+	Region string `input:"region"`
 
 	// Specify a version or alias to add permissions to a published version of the
 	// function.
@@ -85,30 +83,28 @@ type LambdaInvokePermission struct {
 	// the same as a string using a backslash ("\") as an escape character in the
 	// JSON.
 	Statement string `output:"statement"`
-
-	svc lambdaiface.LambdaAPI
 }
 
 // Type returns the type name for an AWS Lambda function.
-func (l *LambdaInvokePermission) Type() string { return "aws_lambda_invoke_permission" }
+func (p *LambdaInvokePermission) Type() string { return "aws_lambda_invoke_permission" }
 
 // Create creates an AWS lambda function.
-func (l *LambdaInvokePermission) Create(ctx context.Context, r *resource.CreateRequest) error {
-	svc, err := l.service(r.Auth)
+func (p *LambdaInvokePermission) Create(ctx context.Context, r *resource.CreateRequest) error {
+	svc, err := lambdaService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
 
 	input := &lambda.AddPermissionInput{
-		Action:           aws.String(l.Action),
-		EventSourceToken: l.EventSourceToken,
-		FunctionName:     aws.String(l.FunctionName),
-		Principal:        aws.String(l.Principal),
-		Qualifier:        l.Qualifier,
-		RevisionId:       l.RevisionID,
-		SourceAccount:    l.SourceAccount,
-		SourceArn:        l.SourceARN,
-		StatementId:      aws.String(l.StatementID),
+		Action:           aws.String(p.Action),
+		EventSourceToken: p.EventSourceToken,
+		FunctionName:     aws.String(p.FunctionName),
+		Principal:        aws.String(p.Principal),
+		Qualifier:        p.Qualifier,
+		RevisionId:       p.RevisionID,
+		SourceAccount:    p.SourceAccount,
+		SourceArn:        p.SourceARN,
+		StatementId:      aws.String(p.StatementID),
 	}
 
 	req := svc.AddPermissionRequest(input)
@@ -118,23 +114,23 @@ func (l *LambdaInvokePermission) Create(ctx context.Context, r *resource.CreateR
 		return err
 	}
 
-	l.Statement = *resp.Statement
+	p.Statement = *resp.Statement
 
 	return nil
 }
 
 // Delete deletes the lambda function.
-func (l *LambdaInvokePermission) Delete(ctx context.Context, r *resource.DeleteRequest) error {
-	svc, err := l.service(r.Auth)
+func (p *LambdaInvokePermission) Delete(ctx context.Context, r *resource.DeleteRequest) error {
+	svc, err := lambdaService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
 
 	req := svc.RemovePermissionRequest(&lambda.RemovePermissionInput{
-		FunctionName: aws.String(l.FunctionName),
-		Qualifier:    l.Qualifier,
-		RevisionId:   l.RevisionID,
-		StatementId:  aws.String(l.StatementID),
+		FunctionName: aws.String(p.FunctionName),
+		Qualifier:    p.Qualifier,
+		RevisionId:   p.RevisionID,
+		StatementId:  aws.String(p.StatementID),
 	})
 	req.SetContext(ctx)
 	_, err = req.Send()
@@ -142,7 +138,7 @@ func (l *LambdaInvokePermission) Delete(ctx context.Context, r *resource.DeleteR
 }
 
 // Update updates the lambda function.
-func (l *LambdaInvokePermission) Update(ctx context.Context, r *resource.UpdateRequest) error {
+func (p *LambdaInvokePermission) Update(ctx context.Context, r *resource.UpdateRequest) error {
 	// Permission cannot be updated, delete and create nwe
 
 	prev := r.Previous.(*LambdaInvokePermission)
@@ -150,20 +146,9 @@ func (l *LambdaInvokePermission) Update(ctx context.Context, r *resource.UpdateR
 	if err := prev.Delete(ctx, r.DeleteRequest()); err != nil {
 		return errors.Wrap(err, "update-delete")
 	}
-	if err := l.Create(ctx, r.CreateRequest()); err != nil {
+	if err := p.Create(ctx, r.CreateRequest()); err != nil {
 		return errors.Wrap(err, "update-create")
 	}
 
 	return nil
-}
-
-func (l *LambdaInvokePermission) service(auth resource.AuthProvider) (lambdaiface.LambdaAPI, error) {
-	if l.svc == nil {
-		cfg, err := config.WithRegion(auth, l.Region)
-		if err != nil {
-			return nil, errors.Wrap(err, "get aws config")
-		}
-		l.svc = lambda.New(cfg)
-	}
-	return l.svc, nil
 }

--- a/provider/aws/services.go
+++ b/provider/aws/services.go
@@ -1,0 +1,122 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/defaults"
+	"github.com/aws/aws-sdk-go-v2/aws/endpoints"
+	"github.com/aws/aws-sdk-go-v2/aws/external"
+	"github.com/aws/aws-sdk-go-v2/service/apigateway"
+	"github.com/aws/aws-sdk-go-v2/service/apigateway/apigatewayiface"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/iamiface"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/lambda/lambdaiface"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/aws-sdk-go-v2/service/sts/stsiface"
+	"github.com/func/func/resource"
+	"github.com/pkg/errors"
+)
+
+// If a mock service is set, the corresponding mock api client is returned when
+// a client is requested.
+var (
+	mockAPIGatewayService apigatewayiface.APIGatewayAPI
+	mockIAMService        iamiface.IAMAPI
+	mockLambdaService     lambdaiface.LambdaAPI
+	mockSTSService        stsiface.STSAPI
+)
+
+func apigatewayService(auth resource.AuthProvider, region string) (apigatewayiface.APIGatewayAPI, error) {
+	if mockAPIGatewayService != nil {
+		return mockAPIGatewayService, nil
+	}
+	cfg, err := awsConfig(auth, region)
+	if err != nil {
+		return nil, err
+	}
+	return apigateway.New(cfg), nil
+}
+
+func iamService(auth resource.AuthProvider, region *string) (iamiface.IAMAPI, error) {
+	if mockIAMService != nil {
+		return mockIAMService, nil
+	}
+	var reg string
+	if region != nil {
+		reg = *region
+	} else {
+		reg = defaultRegion()
+	}
+	cfg, err := awsConfig(auth, reg)
+	if err != nil {
+		return nil, err
+	}
+	return iam.New(cfg), nil
+}
+
+func lambdaService(auth resource.AuthProvider, region string) (lambdaiface.LambdaAPI, error) {
+	if mockLambdaService != nil {
+		return mockLambdaService, nil
+	}
+	cfg, err := awsConfig(auth, region)
+	if err != nil {
+		return nil, err
+	}
+	return lambda.New(cfg), nil
+}
+
+func stsService(auth resource.AuthProvider, region *string) (stsiface.STSAPI, error) {
+	if mockSTSService != nil {
+		return mockSTSService, nil
+	}
+	var reg string
+	if region != nil {
+		reg = *region
+	} else {
+		reg = defaultRegion()
+	}
+	cfg, err := awsConfig(auth, reg)
+	if err != nil {
+		return nil, err
+	}
+	return sts.New(cfg), nil
+}
+
+// ---
+
+func awsConfig(auth resource.AuthProvider, region string) (aws.Config, error) {
+	cfg := defaults.Config()
+	creds, err := auth.AWS()
+	if err != nil {
+		return aws.Config{}, errors.Wrap(err, "get credentials")
+	}
+	cfg.Region = region
+	cfg.Credentials = creds
+	cfg.Region = region
+	return cfg, nil
+}
+
+// defaultRegion determines the default region to use based on:
+//
+//  - From AWS_DEFAULT_REGION environment variable.
+//  - From region in ~/.aws/credentials.
+//  - If neither is set, us-east-1 is used.
+func defaultRegion() string {
+	const fallback = endpoints.UsEast1RegionID
+	var cfgs external.Configs
+	cfgs, err := cfgs.AppendFromLoaders(external.DefaultConfigLoaders)
+	if err != nil {
+		return fallback
+	}
+	cfg, err := cfgs.ResolveAWSConfig([]external.AWSConfigResolver{
+		external.ResolveRegion,
+	})
+	if err != nil {
+		return fallback
+	}
+	if cfg.Region == "" {
+		// No AWS config available
+		return fallback
+	}
+	return cfg.Region
+}

--- a/provider/aws/sts_caller_identity.go
+++ b/provider/aws/sts_caller_identity.go
@@ -47,8 +47,7 @@ func (p *STSCallerIdentity) Create(ctx context.Context, r *resource.CreateReques
 	}
 
 	req := svc.GetCallerIdentityRequest(&sts.GetCallerIdentityInput{})
-	req.SetContext(ctx)
-	resp, err := req.Send()
+	resp, err := req.Send(ctx)
 	if err != nil {
 		return err
 	}

--- a/provider/aws/sts_caller_identity.go
+++ b/provider/aws/sts_caller_identity.go
@@ -7,8 +7,6 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/aws/aws-sdk-go-v2/service/sts/stsiface"
-	"github.com/func/func/provider/aws/internal/config"
 	"github.com/func/func/resource"
 	"github.com/pkg/errors"
 )
@@ -24,14 +22,18 @@ type STSCallerIdentity struct {
 	// The AWS ARN associated with the calling entity.
 	ARN string `output:"arn"`
 
+	// Region to use for STS API calls.
+	//
+	// STS is global so the calls are not regional but the Region will specify
+	// which region the API calls are sent to.
+	Region *string
+
 	// The unique identifier of the calling entity. The exact value depends on
 	// the type of entity making the call. The values returned are those listed
 	// in the aws:userid column in the
 	// [Principal table](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable)
 	// found on the Policy Variables reference page in the IAM User Guide.
 	UserID string `output:"user_id"`
-
-	svc stsiface.STSAPI
 }
 
 // Type returns the type name for an AWS IAM policy resource.
@@ -39,7 +41,7 @@ func (p *STSCallerIdentity) Type() string { return "aws_sts_caller_identity" }
 
 // Create reads the current caller identity
 func (p *STSCallerIdentity) Create(ctx context.Context, r *resource.CreateRequest) error {
-	svc, err := p.service(r.Auth)
+	svc, err := stsService(r.Auth, p.Region)
 	if err != nil {
 		return errors.Wrap(err, "get client")
 	}
@@ -66,15 +68,4 @@ func (p *STSCallerIdentity) Delete(ctx context.Context, r *resource.DeleteReques
 // Update returns an error. A policy cannot be updated.
 func (p *STSCallerIdentity) Update(ctx context.Context, r *resource.UpdateRequest) error {
 	return nil
-}
-
-func (p *STSCallerIdentity) service(auth resource.AuthProvider) (stsiface.STSAPI, error) {
-	if p.svc == nil {
-		cfg, err := config.DefaultRegion(auth)
-		if err != nil {
-			return nil, errors.Wrap(err, "get aws config")
-		}
-		p.svc = sts.New(cfg)
-	}
-	return p.svc, nil
 }

--- a/source/s3/s3.go
+++ b/source/s3/s3.go
@@ -43,8 +43,7 @@ func (s *Storage) Has(ctx context.Context, filename string) (bool, error) {
 	}
 
 	req := s.Client.HeadObjectRequest(input)
-	req.SetContext(ctx)
-	_, err := req.Send()
+	_, err := req.Send(ctx)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == "NotFound" {
@@ -70,8 +69,7 @@ func (s *Storage) Get(ctx context.Context, filename string) (io.ReadCloser, erro
 		Bucket: aws.String(s.Bucket),
 		Key:    aws.String(filename),
 	})
-	req.SetContext(ctx)
-	res, err := req.Send()
+	res, err := req.Send(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "send request")
 	}

--- a/source/s3/s3_test.go
+++ b/source/s3/s3_test.go
@@ -152,7 +152,9 @@ func getAPI(t *testing.T) *s3.S3 {
 func makeBucket(t *testing.T, cli s3iface.S3API, name string) func() {
 	t.Helper()
 
-	_, err := cli.CreateBucketRequest(&s3.CreateBucketInput{Bucket: aws.String(name)}).Send()
+	ctx := context.Background()
+
+	_, err := cli.CreateBucketRequest(&s3.CreateBucketInput{Bucket: aws.String(name)}).Send(ctx)
 	if err != nil {
 		t.Fatalf("create bucket: %v", err)
 	}
@@ -160,7 +162,7 @@ func makeBucket(t *testing.T, cli s3iface.S3API, name string) func() {
 	cleanup := func() {
 		res, err := cli.ListObjectsV2Request(&s3.ListObjectsV2Input{
 			Bucket: aws.String(name),
-		}).Send()
+		}).Send(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -177,11 +179,11 @@ func makeBucket(t *testing.T, cli s3iface.S3API, name string) func() {
 			Delete: &s3.Delete{
 				Objects: ids,
 			},
-		}).Send(); err != nil {
+		}).Send(ctx); err != nil {
 			t.Fatal(err)
 		}
 
-		if _, err = cli.DeleteBucketRequest(&s3.DeleteBucketInput{Bucket: aws.String(name)}).Send(); err != nil {
+		if _, err = cli.DeleteBucketRequest(&s3.DeleteBucketInput{Bucket: aws.String(name)}).Send(ctx); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/tools/structdoc/structdoc/parse.go
+++ b/tools/structdoc/structdoc/parse.go
@@ -79,9 +79,12 @@ func Parse(r io.Reader, typename string) (*Struct, error) {
 }
 
 func parseFields(t *ast.StructType) ([]Field, error) {
-	fields := make([]Field, len(t.Fields.List))
+	var fields []Field // nolint: prealloc
 
-	for i, f := range t.Fields.List {
+	for _, f := range t.Fields.List {
+		if len(f.Names) == 0 {
+			continue
+		}
 		name := f.Names[0].Name
 		tags, err := parseTags(f)
 		if err != nil {
@@ -94,7 +97,7 @@ func parseFields(t *ast.StructType) ([]Field, error) {
 			Tags:    tags,
 		}
 		setType(f.Type, &out)
-		fields[i] = out
+		fields = append(fields, out)
 	}
 
 	return fields, nil


### PR DESCRIPTION
Services are retrieved using `xxxService`. This simplifies the code a bit without other changes. Services can be mocked in tests by setting `mockXXXService`.

Also updated to latest `v0.8.0` sdk which makes `ctx` required in `Send()`.