### PR TITLE
Fix API retry

### DIFF
--- a/api/apply.go
+++ b/api/apply.go
@@ -31,7 +31,7 @@ func (f *Func) Apply(ctx context.Context, req *ApplyRequest) (*ApplyResponse, er
 	}
 	proj, srcs, diags := dec.DecodeBody(req.Config, g)
 	if diags.HasErrors() {
-		return nil, diags
+		return nil, NewDiagnosticsError(diags)
 	}
 
 	if proj == nil {

--- a/api/error.go
+++ b/api/error.go
@@ -1,0 +1,39 @@
+package api
+
+import "github.com/hashicorp/hcl2/hcl"
+
+// A RetryableError is returned when an api call can be retried.
+type RetryableError interface {
+	CanRetry() bool
+}
+
+type retryErr struct {
+	err error
+}
+
+func (e retryErr) Error() string  { return e.err.Error() }
+func (e retryErr) CanRetry() bool { return true }
+
+// NewRetryableError creates a new retryable error.
+func NewRetryableError(err error) error {
+	return retryErr{err: err}
+}
+
+// A DiagnosticsError is returned when the error contains diagnostics.
+// This is always a user error.
+type DiagnosticsError interface {
+	Diagnostics() hcl.Diagnostics
+}
+
+type diagsErr struct {
+	diags hcl.Diagnostics
+}
+
+// Diagnostics returns embedded diagnostics.
+func (e *diagsErr) Diagnostics() hcl.Diagnostics { return e.diags }
+func (e *diagsErr) Error() string                { return e.diags.Error() }
+
+// NewDiagnosticsError creates a new error that contains diagnostics.
+func NewDiagnosticsError(diagnostics hcl.Diagnostics) error {
+	return &diagsErr{diags: diagnostics}
+}


### PR DESCRIPTION
Previously requests would retry too often, for example on status `409` from aws. Now we only explicitly opt-in to retry, rather than defaulting to always retry.