### PR TITLE
Split resource to desired and deployed

### DIFF
--- a/cmd/func/server.go
+++ b/cmd/func/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/func/func/source/s3"
 	"github.com/func/func/storage/dynamodb"
 	"github.com/mattn/go-isatty"
+	"github.com/segmentio/ksuid"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
@@ -99,6 +100,9 @@ var serverCommand = &cobra.Command{
 				Resources: dynamo,
 				Source:    s3src,
 				Registry:  reg,
+				IDGen: reconciler.IDGeneratorFunc(func() string {
+					return ksuid.New().String()
+				}),
 			},
 		}
 

--- a/resource/graph.go
+++ b/resource/graph.go
@@ -8,14 +8,14 @@ import (
 
 // A Graph contains a resources and relationships between resources.
 type Graph struct {
-	Resources    []*Resource
+	Resources    []*Desired
 	Dependencies []*Dependency
 }
 
 // AddResource adds a new resource to the graph.
 //
 // Returns an error if another resource with an identical name already exists.
-func (g *Graph) AddResource(res *Resource) error {
+func (g *Graph) AddResource(res *Desired) error {
 	if res.Name == "" {
 		return fmt.Errorf("resource has no name")
 	}
@@ -31,7 +31,7 @@ func (g *Graph) AddResource(res *Resource) error {
 
 // Resource returns a resource with a given name from the graph.
 // Returns nil if the resource does not exist.
-func (g *Graph) Resource(name string) *Resource {
+func (g *Graph) Resource(name string) *Desired {
 	for _, r := range g.Resources {
 		if r.Name == name {
 			return r
@@ -65,9 +65,9 @@ func (g *Graph) AddDependency(dep *Dependency) error {
 // ParentResources returns the parent resources that are are a dependency to
 // the given child resource. In case multiple references exist to the parent
 // resource, it is included only once.
-func (g *Graph) ParentResources(child string) []*Resource {
+func (g *Graph) ParentResources(child string) []*Desired {
 	added := make(map[string]struct{}) // Avoid adding the same dependency twice
-	var parents []*Resource
+	var parents []*Desired
 	for _, d := range g.Dependencies {
 		if d.Child != child {
 			continue
@@ -95,7 +95,7 @@ func (g *Graph) DependenciesOf(child string) []*Dependency {
 }
 
 // LeafResources returns all resources that have no children.
-func (g *Graph) LeafResources() []*Resource {
+func (g *Graph) LeafResources() []*Desired {
 	parents := make(map[string]struct{})
 
 	// Mark resources that are dependencies to child resources.
@@ -110,7 +110,7 @@ func (g *Graph) LeafResources() []*Resource {
 	}
 
 	// Collect remaining resources that were not marked.
-	out := make([]*Resource, 0, len(g.Resources)-len(parents))
+	out := make([]*Desired, 0, len(g.Resources)-len(parents))
 	for _, res := range g.Resources {
 		_, isParent := parents[res.Name]
 		if !isParent {

--- a/resource/graph_test.go
+++ b/resource/graph_test.go
@@ -10,14 +10,14 @@ import (
 func TestGraph_AddResource(t *testing.T) {
 	g := &Graph{}
 
-	a := &Resource{Type: "aaa", Name: "a"}
+	a := &Desired{Type: "aaa", Name: "a"}
 
 	if err := g.AddResource(a); err != nil {
 		t.Fatalf("AddResource() err = %v", err)
 	}
 
 	want := &Graph{
-		Resources: []*Resource{a},
+		Resources: []*Desired{a},
 	}
 	opts := []cmp.Option{
 		cmp.Comparer(func(a, b cty.Value) bool { return a.Equals(b).True() }),
@@ -29,12 +29,12 @@ func TestGraph_AddResource(t *testing.T) {
 
 func TestGraph_AddResource_existing(t *testing.T) {
 	g := &Graph{
-		Resources: []*Resource{
+		Resources: []*Desired{
 			{Type: "foo", Name: "a"},
 		},
 	}
 
-	err := g.AddResource(&Resource{Type: "bar", Name: "a"}) // same name
+	err := g.AddResource(&Desired{Type: "bar", Name: "a"}) // same name
 	if err == nil {
 		t.Fatalf("Want error")
 	}
@@ -42,7 +42,7 @@ func TestGraph_AddResource_existing(t *testing.T) {
 
 func TestGraph_AddResource_ErrNoName(t *testing.T) {
 	g := &Graph{}
-	err := g.AddResource(&Resource{Name: "", Type: "foo"})
+	err := g.AddResource(&Desired{Name: "", Type: "foo"})
 	if err == nil {
 		t.Fatalf("Want error")
 	}
@@ -50,7 +50,7 @@ func TestGraph_AddResource_ErrNoName(t *testing.T) {
 
 func TestGraph_AddResource_ErrNoType(t *testing.T) {
 	g := &Graph{}
-	err := g.AddResource(&Resource{Name: "foo", Type: ""})
+	err := g.AddResource(&Desired{Name: "foo", Type: ""})
 	if err == nil {
 		t.Fatalf("Want error")
 	}
@@ -58,7 +58,7 @@ func TestGraph_AddResource_ErrNoType(t *testing.T) {
 
 func TestGraph_AddDependency(t *testing.T) {
 	g := &Graph{
-		Resources: []*Resource{
+		Resources: []*Desired{
 			{Type: "foo", Name: "a"},
 			{Type: "bar", Name: "b"},
 		},
@@ -79,7 +79,7 @@ func TestGraph_AddDependency(t *testing.T) {
 	}
 
 	want := &Graph{
-		Resources: []*Resource{
+		Resources: []*Desired{
 			{Type: "foo", Name: "a"},
 			{Type: "bar", Name: "b"},
 		},
@@ -96,7 +96,7 @@ func TestGraph_AddDependency(t *testing.T) {
 
 func TestGraph_AddDependency_ErrMissingChild(t *testing.T) {
 	g := &Graph{
-		Resources: []*Resource{
+		Resources: []*Desired{
 			{Type: "foo", Name: "a"},
 			{Type: "bar", Name: "b"},
 		},
@@ -120,7 +120,7 @@ func TestGraph_AddDependency_ErrMissingChild(t *testing.T) {
 
 func TestGraph_AddDependency_ErrMissingParent(t *testing.T) {
 	g := &Graph{
-		Resources: []*Resource{
+		Resources: []*Desired{
 			{Type: "foo", Name: "a"},
 			{Type: "bar", Name: "b"},
 		},
@@ -144,7 +144,7 @@ func TestGraph_AddDependency_ErrMissingParent(t *testing.T) {
 
 func TestGraph_AddDependency_ErrInvalidPath(t *testing.T) {
 	g := &Graph{
-		Resources: []*Resource{
+		Resources: []*Desired{
 			{Type: "foo", Name: "a"},
 			{Type: "bar", Name: "b"},
 		},
@@ -167,11 +167,11 @@ func TestGraph_AddDependency_ErrInvalidPath(t *testing.T) {
 }
 
 func TestGraph_ParentResources(t *testing.T) {
-	a := &Resource{Type: "foo", Name: "a"}
-	b := &Resource{Type: "foo", Name: "b"}
+	a := &Desired{Type: "foo", Name: "a"}
+	b := &Desired{Type: "foo", Name: "b"}
 
 	g := &Graph{
-		Resources: []*Resource{a, b},
+		Resources: []*Desired{a, b},
 		Dependencies: []*Dependency{
 			{
 				Child: "b",
@@ -199,21 +199,21 @@ func TestGraph_ParentResources(t *testing.T) {
 	}
 
 	got := g.ParentResources("a")
-	want := ([]*Resource)(nil)
+	want := ([]*Desired)(nil)
 	if diff := cmp.Diff(got, want, opts...); diff != "" {
 		t.Errorf("Parent resources a (-got +want)\n%s", diff)
 	}
 
 	got = g.ParentResources("b")
-	want = []*Resource{a}
+	want = []*Desired{a}
 	if diff := cmp.Diff(got, want, opts...); diff != "" {
 		t.Errorf("Parent resources b (-got +want)\n%s", diff)
 	}
 }
 
 func TestGraph_DependenciesOf(t *testing.T) {
-	a := &Resource{Type: "foo", Name: "a"}
-	b := &Resource{Type: "foo", Name: "b"}
+	a := &Desired{Type: "foo", Name: "a"}
+	b := &Desired{Type: "foo", Name: "b"}
 
 	dep1 := &Dependency{
 		Child: "b",
@@ -235,7 +235,7 @@ func TestGraph_DependenciesOf(t *testing.T) {
 	}
 
 	g := &Graph{
-		Resources:    []*Resource{a, b},
+		Resources:    []*Desired{a, b},
 		Dependencies: []*Dependency{dep1, dep2},
 	}
 
@@ -258,12 +258,12 @@ func TestGraph_DependenciesOf(t *testing.T) {
 }
 
 func TestGraph_LeafResources(t *testing.T) {
-	a := &Resource{Type: "foo", Name: "a"}
-	b := &Resource{Type: "bar", Name: "b"}
-	c := &Resource{Type: "baz", Name: "c"}
-	d := &Resource{Type: "qux", Name: "d"}
+	a := &Desired{Type: "foo", Name: "a"}
+	b := &Desired{Type: "bar", Name: "b"}
+	c := &Desired{Type: "baz", Name: "c"}
+	d := &Desired{Type: "qux", Name: "d"}
 	g := &Graph{
-		Resources: []*Resource{
+		Resources: []*Desired{
 			a, b, c, d,
 		},
 		Dependencies: []*Dependency{
@@ -291,7 +291,7 @@ func TestGraph_LeafResources(t *testing.T) {
 	}
 
 	got := g.LeafResources()
-	want := []*Resource{c, d} // c and d have no children
+	want := []*Desired{c, d} // c and d have no children
 
 	opts := []cmp.Option{
 		cmp.Comparer(func(a, b cty.Value) bool { return a.Equals(b).True() }),

--- a/resource/hcldecoder/decoder_test.go
+++ b/resource/hcldecoder/decoder_test.go
@@ -38,7 +38,7 @@ func TestDecodeBody(t *testing.T) {
 			`,
 			types: map[string]reflect.Type{"a": reflect.TypeOf(simpleDef{})},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "a",
 						Name: "foo",
@@ -65,7 +65,7 @@ func TestDecodeBody(t *testing.T) {
 				}{}),
 			},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "a",
 						Name: "foo",
@@ -92,7 +92,7 @@ func TestDecodeBody(t *testing.T) {
 			`,
 			types: map[string]reflect.Type{"a": reflect.TypeOf(simpleDef{})},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type:    "a",
 						Name:    "foo",
@@ -121,7 +121,7 @@ func TestDecodeBody(t *testing.T) {
 			`,
 			types: map[string]reflect.Type{"a": reflect.TypeOf(simpleDef{})},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "a",
 						Name: "foo",
@@ -135,7 +135,6 @@ func TestDecodeBody(t *testing.T) {
 						Input: cty.ObjectVal(map[string]cty.Value{
 							"input": cty.StringVal("hello"), // Can be statically resolved.
 						}),
-						Deps: []string{"foo"},
 					},
 				},
 			},
@@ -158,7 +157,7 @@ func TestDecodeBody(t *testing.T) {
 			`,
 			types: map[string]reflect.Type{"a": reflect.TypeOf(simpleDef{})},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "a",
 						Name: "foo",
@@ -172,7 +171,6 @@ func TestDecodeBody(t *testing.T) {
 						Input: cty.ObjectVal(map[string]cty.Value{
 							"input": cty.StringVal("hello"), // Can be statically resolved.
 						}),
-						Deps: []string{"foo"},
 					},
 					{
 						Type: "a",
@@ -180,7 +178,6 @@ func TestDecodeBody(t *testing.T) {
 						Input: cty.ObjectVal(map[string]cty.Value{
 							"input": cty.StringVal("hello"), // Can be transitively resolved.
 						}),
-						Deps: []string{"bar"},
 					},
 				},
 			},
@@ -199,7 +196,7 @@ func TestDecodeBody(t *testing.T) {
 			`,
 			types: map[string]reflect.Type{"a": reflect.TypeOf(simpleDef{})},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "a",
 						Name: "foo",
@@ -213,7 +210,6 @@ func TestDecodeBody(t *testing.T) {
 						Input: cty.ObjectVal(map[string]cty.Value{
 							"input": cty.UnknownVal(cty.String),
 						}),
-						Deps: []string{"foo"},
 					},
 				},
 				Dependencies: []*resource.Dependency{
@@ -247,7 +243,7 @@ func TestDecodeBody(t *testing.T) {
 			`,
 			types: map[string]reflect.Type{"a": reflect.TypeOf(simpleDef{})},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "a",
 						Name: "foo",
@@ -268,7 +264,6 @@ func TestDecodeBody(t *testing.T) {
 						Input: cty.ObjectVal(map[string]cty.Value{
 							"input": cty.UnknownVal(cty.String),
 						}),
-						Deps: []string{"foo", "bar"}, // foo only appears once
 					},
 				},
 				Dependencies: []*resource.Dependency{
@@ -298,7 +293,7 @@ func TestDecodeBody(t *testing.T) {
 				}{}),
 			},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "ptr",
 						Name: "foo",
@@ -325,7 +320,7 @@ func TestDecodeBody(t *testing.T) {
 				}{}),
 			},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "mapdef",
 						Name: "foo",
@@ -352,7 +347,7 @@ func TestDecodeBody(t *testing.T) {
 				}{}),
 			},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "slicedef",
 						Name: "foo",
@@ -388,7 +383,7 @@ func TestDecodeBody(t *testing.T) {
 				}{}),
 			},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "structdef",
 						Name: "foo",
@@ -418,7 +413,7 @@ func TestDecodeBody(t *testing.T) {
 				}{}),
 			},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "structdef",
 						Name: "foo",
@@ -446,7 +441,7 @@ func TestDecodeBody(t *testing.T) {
 				}{}),
 			},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "bar",
 						Name: "foo",
@@ -477,7 +472,7 @@ func TestDecodeBody(t *testing.T) {
 				}{}),
 			},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "pie",
 						Name: "foo",
@@ -514,7 +509,7 @@ func TestDecodeBody(t *testing.T) {
 				}{}),
 			},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "multi",
 						Name: "foo",
@@ -555,7 +550,7 @@ func TestDecodeBody(t *testing.T) {
 				}{}),
 			},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "multi",
 						Name: "foo",
@@ -591,7 +586,7 @@ func TestDecodeBody(t *testing.T) {
 				"simple": reflect.TypeOf(simpleDef{}),
 			},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type:  "complex",
 						Name:  "foo",
@@ -603,7 +598,6 @@ func TestDecodeBody(t *testing.T) {
 						Input: cty.ObjectVal(map[string]cty.Value{
 							"input": cty.UnknownVal(cty.String),
 						}),
-						Deps: []string{"foo"},
 					},
 				},
 				Dependencies: []*resource.Dependency{
@@ -637,7 +631,7 @@ func TestDecodeBody(t *testing.T) {
 				"simple": reflect.TypeOf(simpleDef{}),
 			},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type:  "complex",
 						Name:  "foo",
@@ -649,7 +643,6 @@ func TestDecodeBody(t *testing.T) {
 						Input: cty.ObjectVal(map[string]cty.Value{
 							"input": cty.UnknownVal(cty.String),
 						}),
-						Deps: []string{"foo"},
 					},
 				},
 				Dependencies: []*resource.Dependency{
@@ -689,7 +682,7 @@ func TestDecodeBody(t *testing.T) {
 				"simple": reflect.TypeOf(simpleDef{}),
 			},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type:  "complex",
 						Name:  "foo",
@@ -701,7 +694,6 @@ func TestDecodeBody(t *testing.T) {
 						Input: cty.ObjectVal(map[string]cty.Value{
 							"input": cty.UnknownVal(cty.String),
 						}),
-						Deps: []string{"foo"},
 					},
 				},
 				Dependencies: []*resource.Dependency{
@@ -758,7 +750,7 @@ func TestDecodeBody(t *testing.T) {
 				}{}),
 			},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type: "a",
 						Name: "foo",
@@ -775,7 +767,6 @@ func TestDecodeBody(t *testing.T) {
 								"int":    cty.NumberIntVal(123),
 							}),
 						}),
-						Deps: []string{"foo"},
 					},
 					{
 						Type: "c",
@@ -784,7 +775,6 @@ func TestDecodeBody(t *testing.T) {
 							"num":     cty.UnknownVal(cty.Number),
 							"strings": cty.UnknownVal(cty.List(cty.String)),
 						}),
-						Deps: []string{"bar"},
 					},
 				},
 				Dependencies: []*resource.Dependency{
@@ -834,7 +824,7 @@ func TestDecodeBody(t *testing.T) {
 				"simple": reflect.TypeOf(simpleDef{}),
 			},
 			want: &resource.Graph{
-				Resources: []*resource.Resource{
+				Resources: []*resource.Desired{
 					{
 						Type:  "output",
 						Name:  "foo",
@@ -846,7 +836,6 @@ func TestDecodeBody(t *testing.T) {
 						Input: cty.ObjectVal(map[string]cty.Value{
 							"input": cty.UnknownVal(cty.String),
 						}),
-						Deps: []string{"foo"},
 					},
 					{
 						Type: "simple",
@@ -854,7 +843,6 @@ func TestDecodeBody(t *testing.T) {
 						Input: cty.ObjectVal(map[string]cty.Value{
 							"input": cty.UnknownVal(cty.String),
 						}),
-						Deps: []string{"foo"},
 					},
 				},
 				Dependencies: []*resource.Dependency{
@@ -900,7 +888,7 @@ func TestDecodeBody(t *testing.T) {
 					return a.GoString() == b.GoString()
 				}),
 				// Order of resource or dependencies do not matter
-				cmpopts.SortSlices(func(a, b *resource.Resource) bool { return a.Name < b.Name }),
+				cmpopts.SortSlices(func(a, b *resource.Desired) bool { return a.Name < b.Name }),
 				cmpopts.SortSlices(func(a, b *resource.Dependency) bool {
 					astr := fmt.Sprintf("%+v", a)
 					bstr := fmt.Sprintf("%+v", b)

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -4,8 +4,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// A Resource is an instance of a resource supplied by the user.
-type Resource struct {
+// Desired represents the desired state of a resource.
+type Desired struct {
 	// Name used in resource config.
 	//
 	// The Name uniquely identifies the resource.
@@ -22,6 +22,16 @@ type Resource struct {
 	// given resource type.
 	Input cty.Value
 
+	// Sources contain the source code hashes that were provided to the
+	// resource. The value is only set for resources that have been created.
+	Sources []string
+}
+
+// Deployed is a deployed resource.
+type Deployed struct {
+	// Desired state that resulted in the deployed resource.
+	*Desired
+
 	// Output contains the outputs from the resource. The value is set after
 	// the resource has been provisioned.
 	Output cty.Value
@@ -32,8 +42,4 @@ type Resource struct {
 	//
 	// Deps are used for traversing the graph backwards when deleting resources.
 	Deps []string
-
-	// Sources contain the source code hashes that were provided to the
-	// resource. The value is only set for resources that have been created.
-	Sources []string
 }

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -8,7 +8,8 @@ import (
 type Desired struct {
 	// Name used in resource config.
 	//
-	// The Name uniquely identifies the resource.
+	// The Name uniquely identifies the resource within the user's desired
+	// resource graph.
 	Name string
 
 	// Type used in resource config.
@@ -31,6 +32,10 @@ type Desired struct {
 type Deployed struct {
 	// Desired state that resulted in the deployed resource.
 	*Desired
+
+	// ID is a unique id that is assigned to the resource when it has been
+	// deployed. The ID uniquely identifies the resource.
+	ID string
 
 	// Output contains the outputs from the resource. The value is set after
 	// the resource has been provisioned.

--- a/storage/dynamodb/dynamodb_test.go
+++ b/storage/dynamodb/dynamodb_test.go
@@ -44,6 +44,7 @@ func TestDynamoDB_Resources(t *testing.T) {
 			Name:  "a",
 			Input: cty.ObjectVal(map[string]cty.Value{"input": cty.StringVal("abc")}),
 		},
+		ID:     "a",
 		Output: cty.ObjectVal(map[string]cty.Value{"output": cty.StringVal("def")}),
 	}
 	resB := &resource.Deployed{
@@ -53,8 +54,9 @@ func TestDynamoDB_Resources(t *testing.T) {
 			Input:   cty.ObjectVal(map[string]cty.Value{"input": cty.StringVal("123")}),
 			Sources: []string{"x", "y", "z"},
 		},
-		Deps:   []string{"foo", "bar"},
+		ID:     "b",
 		Output: cty.ObjectVal(map[string]cty.Value{"output": cty.StringVal("456")}),
+		Deps:   []string{"foo", "bar"},
 	}
 
 	// Create
@@ -81,9 +83,10 @@ func TestDynamoDB_Resources(t *testing.T) {
 	update := &resource.Deployed{
 		Desired: &resource.Desired{
 			Type:  "foo",
-			Name:  "a", // Same name
+			Name:  "abcdef", // Different name
 			Input: cty.ObjectVal(map[string]cty.Value{"input": cty.StringVal("ABC")}),
 		},
+		ID:     "a", // Same id
 		Output: cty.ObjectVal(map[string]cty.Value{"output": cty.StringVal("DEF")}),
 	}
 	if err := ddb.PutResource(ctx, project, update); err != nil {

--- a/storage/teststore/recorder.go
+++ b/storage/teststore/recorder.go
@@ -11,9 +11,9 @@ import (
 )
 
 type store interface {
-	PutResource(ctx context.Context, project string, res *resource.Resource) error
-	DeleteResource(ctx context.Context, project string, res *resource.Resource) error
-	ListResources(ctx context.Context, project string) ([]*resource.Resource, error)
+	PutResource(ctx context.Context, project string, res *resource.Deployed) error
+	DeleteResource(ctx context.Context, project string, res *resource.Deployed) error
+	ListResources(ctx context.Context, project string) ([]*resource.Deployed, error)
 	PutGraph(ctx context.Context, project string, g *resource.Graph) error
 	GetGraph(ctx context.Context, project string) (*resource.Graph, error)
 }
@@ -113,7 +113,7 @@ func (ev Event) String() string {
 // PutResource calls the corresponding method on the underlying store and records the event.
 //
 // Resource is set as event data.
-func (r *Recorder) PutResource(ctx context.Context, project string, res *resource.Resource) error {
+func (r *Recorder) PutResource(ctx context.Context, project string, res *resource.Deployed) error {
 	ev := Event{
 		Method:  "PutResource",
 		Project: project,
@@ -132,7 +132,7 @@ func (r *Recorder) PutResource(ctx context.Context, project string, res *resourc
 // DeleteResource calls the corresponding method on the underlying store and records the event.
 //
 // Resource is set as event data.
-func (r *Recorder) DeleteResource(ctx context.Context, project string, res *resource.Resource) error {
+func (r *Recorder) DeleteResource(ctx context.Context, project string, res *resource.Deployed) error {
 	ev := Event{
 		Method:  "DeleteResource",
 		Project: project,
@@ -149,7 +149,7 @@ func (r *Recorder) DeleteResource(ctx context.Context, project string, res *reso
 }
 
 // ListResources calls the corresponding method on the underlying store and records the event.
-func (r *Recorder) ListResources(ctx context.Context, project string) ([]*resource.Resource, error) {
+func (r *Recorder) ListResources(ctx context.Context, project string) ([]*resource.Deployed, error) {
 	ev := Event{
 		Method:  "ListResources",
 		Project: project,

--- a/storage/teststore/store.go
+++ b/storage/teststore/store.go
@@ -12,7 +12,7 @@ import (
 // Store is a store that's intended to be used in tests. All data is stored in memory.
 type Store struct {
 	mu        sync.RWMutex
-	resources map[string]map[string]*resource.Resource
+	resources map[string]map[string]*resource.Deployed
 	graphs    map[string]*resource.Graph
 }
 
@@ -21,15 +21,15 @@ type Store struct {
 //
 // The method may be called multiple times to add resources in parts, or add
 // resources to different projects.
-func (s *Store) SeedResources(project string, resources []*resource.Resource) {
+func (s *Store) SeedResources(project string, resources []*resource.Deployed) {
 	if len(resources) == 0 {
 		return
 	}
 	if s.resources == nil {
-		s.resources = make(map[string]map[string]*resource.Resource)
+		s.resources = make(map[string]map[string]*resource.Deployed)
 	}
 	if s.resources[project] == nil {
-		s.resources[project] = make(map[string]*resource.Resource)
+		s.resources[project] = make(map[string]*resource.Deployed)
 	}
 	for _, res := range resources {
 		s.resources[project][res.Name] = res
@@ -49,21 +49,21 @@ func (s *Store) SeedGraph(project string, g *resource.Graph) {
 }
 
 // PutResource creates or updates a resource.
-func (s *Store) PutResource(ctx context.Context, project string, res *resource.Resource) error {
+func (s *Store) PutResource(ctx context.Context, project string, res *resource.Deployed) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.resources == nil {
-		s.resources = make(map[string]map[string]*resource.Resource)
+		s.resources = make(map[string]map[string]*resource.Deployed)
 	}
 	if s.resources[project] == nil {
-		s.resources[project] = make(map[string]*resource.Resource)
+		s.resources[project] = make(map[string]*resource.Deployed)
 	}
 	s.resources[project][res.Name] = res
 	return nil
 }
 
 // DeleteResource deletes a resource. No-op if the resource does not exist.
-func (s *Store) DeleteResource(ctx context.Context, project string, res *resource.Resource) error {
+func (s *Store) DeleteResource(ctx context.Context, project string, res *resource.Deployed) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.resources[project][res.Name]; !ok {
@@ -74,11 +74,11 @@ func (s *Store) DeleteResource(ctx context.Context, project string, res *resourc
 }
 
 // ListResources lists all resources in a project.
-func (s *Store) ListResources(ctx context.Context, project string) ([]*resource.Resource, error) {
+func (s *Store) ListResources(ctx context.Context, project string) ([]*resource.Deployed, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	rr := s.resources[project]
-	out := make([]*resource.Resource, 0, len(rr))
+	out := make([]*resource.Deployed, 0, len(rr))
 	for _, r := range rr {
 		out = append(out, r)
 	}

--- a/storage/teststore/store.go
+++ b/storage/teststore/store.go
@@ -32,7 +32,7 @@ func (s *Store) SeedResources(project string, resources []*resource.Deployed) {
 		s.resources[project] = make(map[string]*resource.Deployed)
 	}
 	for _, res := range resources {
-		s.resources[project][res.Name] = res
+		s.resources[project][res.ID] = res
 	}
 }
 
@@ -58,7 +58,7 @@ func (s *Store) PutResource(ctx context.Context, project string, res *resource.D
 	if s.resources[project] == nil {
 		s.resources[project] = make(map[string]*resource.Deployed)
 	}
-	s.resources[project][res.Name] = res
+	s.resources[project][res.ID] = res
 	return nil
 }
 
@@ -66,10 +66,10 @@ func (s *Store) PutResource(ctx context.Context, project string, res *resource.D
 func (s *Store) DeleteResource(ctx context.Context, project string, res *resource.Deployed) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, ok := s.resources[project][res.Name]; !ok {
-		return fmt.Errorf("resource %q does not exist in project %q", res.Name, project)
+	if _, ok := s.resources[project][res.ID]; !ok {
+		return fmt.Errorf("resource %q does not exist in project %q", res.ID, project)
 	}
-	delete(s.resources[project], res.Name)
+	delete(s.resources[project], res.ID)
 	return nil
 }
 
@@ -83,7 +83,7 @@ func (s *Store) ListResources(ctx context.Context, project string) ([]*resource.
 		out = append(out, r)
 	}
 	sort.Slice(out, func(i, j int) bool {
-		return out[i].Name < out[j].Name
+		return out[i].ID < out[j].ID
 	})
 	return out, nil
 }

--- a/storage/teststore/store_test.go
+++ b/storage/teststore/store_test.go
@@ -17,19 +17,23 @@ func TestStore_Resources(t *testing.T) {
 	project := "testproject"
 	ctx := context.Background()
 
-	resA := &resource.Resource{
-		Type:   "foo",
-		Name:   "a",
-		Input:  cty.ObjectVal(map[string]cty.Value{"input": cty.StringVal("abc")}),
+	resA := &resource.Deployed{
+		Desired: &resource.Desired{
+			Type:  "foo",
+			Name:  "a",
+			Input: cty.ObjectVal(map[string]cty.Value{"input": cty.StringVal("abc")}),
+		},
 		Output: cty.ObjectVal(map[string]cty.Value{"output": cty.StringVal("def")}),
 	}
-	resB := &resource.Resource{
-		Type:    "foo",
-		Name:    "b",
-		Input:   cty.ObjectVal(map[string]cty.Value{"input": cty.StringVal("123")}),
-		Output:  cty.ObjectVal(map[string]cty.Value{"output": cty.StringVal("456")}),
-		Sources: []string{"x", "y", "z"},
-		Deps:    []string{"foo", "bar"},
+	resB := &resource.Deployed{
+		Desired: &resource.Desired{
+			Type:    "foo",
+			Name:    "b",
+			Input:   cty.ObjectVal(map[string]cty.Value{"input": cty.StringVal("123")}),
+			Sources: []string{"x", "y", "z"},
+		},
+		Output: cty.ObjectVal(map[string]cty.Value{"output": cty.StringVal("456")}),
+		Deps:   []string{"foo", "bar"},
 	}
 
 	// Create
@@ -44,7 +48,7 @@ func TestStore_Resources(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []*resource.Resource{
+	want := []*resource.Deployed{
 		resA,
 		resB,
 	}
@@ -53,10 +57,12 @@ func TestStore_Resources(t *testing.T) {
 	}
 
 	// Update
-	update := &resource.Resource{
-		Type:   "foo",
-		Name:   "a", // Same name
-		Input:  cty.ObjectVal(map[string]cty.Value{"input": cty.StringVal("ABC")}),
+	update := &resource.Deployed{
+		Desired: &resource.Desired{
+			Type:  "foo",
+			Name:  "a", // Same name
+			Input: cty.ObjectVal(map[string]cty.Value{"input": cty.StringVal("ABC")}),
+		},
 		Output: cty.ObjectVal(map[string]cty.Value{"output": cty.StringVal("DEF")}),
 	}
 	if err := s.PutResource(ctx, project, update); err != nil {
@@ -72,7 +78,7 @@ func TestStore_Resources(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want = []*resource.Resource{
+	want = []*resource.Deployed{
 		update, // a is updated
 		// b is deleted
 	}
@@ -88,7 +94,7 @@ func TestStore_Graphs(t *testing.T) {
 	ctx := context.Background()
 
 	g := &resource.Graph{
-		Resources: []*resource.Resource{
+		Resources: []*resource.Desired{
 			{
 				Name:    "alice",
 				Type:    "person",
@@ -106,7 +112,6 @@ func TestStore_Graphs(t *testing.T) {
 					"name": cty.StringVal("bob"),
 					"age":  cty.NumberIntVal(30),
 				}),
-				Deps: []string{"alice", "carol"},
 			},
 		},
 		Dependencies: []*resource.Dependency{

--- a/storage/teststore/store_test.go
+++ b/storage/teststore/store_test.go
@@ -23,6 +23,7 @@ func TestStore_Resources(t *testing.T) {
 			Name:  "a",
 			Input: cty.ObjectVal(map[string]cty.Value{"input": cty.StringVal("abc")}),
 		},
+		ID:     "a",
 		Output: cty.ObjectVal(map[string]cty.Value{"output": cty.StringVal("def")}),
 	}
 	resB := &resource.Deployed{
@@ -32,6 +33,7 @@ func TestStore_Resources(t *testing.T) {
 			Input:   cty.ObjectVal(map[string]cty.Value{"input": cty.StringVal("123")}),
 			Sources: []string{"x", "y", "z"},
 		},
+		ID:     "b",
 		Output: cty.ObjectVal(map[string]cty.Value{"output": cty.StringVal("456")}),
 		Deps:   []string{"foo", "bar"},
 	}
@@ -60,9 +62,10 @@ func TestStore_Resources(t *testing.T) {
 	update := &resource.Deployed{
 		Desired: &resource.Desired{
 			Type:  "foo",
-			Name:  "a", // Same name
+			Name:  "abcdef", // Different name
 			Input: cty.ObjectVal(map[string]cty.Value{"input": cty.StringVal("ABC")}),
 		},
+		ID:     "a", // Same id
 		Output: cty.ObjectVal(map[string]cty.Value{"output": cty.StringVal("DEF")}),
 	}
 	if err := s.PutResource(ctx, project, update); err != nil {


### PR DESCRIPTION
`resource.Resource` is now split up into `resource.Desired` and `resource.Deployed`. The `Desired` resource is built based on the user config, the `Deployed` one represents a resource that has been provisioned. Deployed resources are identified by an `ID`, which is generated when the resource is created.

Parents dependencies that were required for a resource are resolved in reconciliation (based on the graph), rather decoding the graph.

Using the id to identify resources allows resources to be matched even if the name does not match:

```diff
-resource "oldname" {
+resource "newname" {
  type = "type"
}
```

This is not supported yet (the new resource would be created first, which likely will cause a conflict).